### PR TITLE
add range check for seeking, add seekToLive and seekToStart

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -603,24 +603,23 @@ public class AudioPlayer: NSObject {
     public func seekToTime(time: NSTimeInterval) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let seekableStart = seekableRange!.start
-        let seekableEnd = seekableRange!.end
-        
-        // check if time is in seekable range
-        if time >= seekableStart && time <= seekableEnd {
-            // time is in seekable range
-            player?.seekToTime(time)
+        if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
+            // check if time is in seekable range
+            if time >= seekableStart && time <= seekableEnd {
+                // time is in seekable range
+                player?.seekToTime(time)
+            }
+            else if time < seekableStart {
+                // time is before seekable start, so just move to the most early position as possible
+                seekToStart()
+            }
+            else if time > seekableEnd {
+                // time is larger than possibly, so just move forward as far as possible
+                seekToLive()
+            }
+            
+            updateNowPlayingInfoCenter()
         }
-        else if time < seekableStart {
-            // time is before seekable start, so just move to the most early position as possible
-            seekToStart()
-        }
-        else if time > seekableEnd {
-            // time is larger than possibly, so just move forward as far as possible
-            seekToLive()
-        }
-
-        updateNowPlayingInfoCenter()
     }
     
     /**

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -633,13 +633,6 @@ public class AudioPlayer: NSObject {
         player?.seekToTime(newPos)
         updateNowPlayingInfoCenter()
     }
-    
-    private func getSeekableBordersWithBufferTime(bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
-        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
-        let earliesPoint = min(seekableRange!.end, seekableRange!.start + bufferTime)
-        return (earliesPoint, latestPoint)
-    }
 
     /**
      Seeks backwards as far as possible.
@@ -652,6 +645,15 @@ public class AudioPlayer: NSObject {
         
         player?.seekToTime(newPos)
         updateNowPlayingInfoCenter()
+    }
+    
+    private func getSeekableBordersWithBufferTime(var bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
+        let marginBuffer = CMTime(seconds: 1, preferredTimescale: 1000000000)
+        bufferTime = max(bufferTime, marginBuffer)
+        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
+        let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
+        let earliesPoint = min(seekableRange!.end, seekableRange!.start + marginBuffer)
+        return (earliesPoint, latestPoint)
     }
 
     /**

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -601,7 +601,49 @@ public class AudioPlayer: NSObject {
     - parameter time: The time to seek to.
     */
     public func seekToTime(time: NSTimeInterval) {
-        player?.seekToTime(CMTimeMake(Int64(time), 1))
+        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
+        let seekableStart = seekableRange!.start.seconds
+        let seekableEnd = seekableRange!.end.seconds
+        
+        // check if time is in seekable range
+        if time >= seekableStart && time <= seekableEnd {
+            // time is in seekable range
+            player?.seekToTime(CMTimeMake(Int64(time), 1))
+        } else if time < seekableStart {
+            // time is before seekable start, so just move to the most early position as possible
+            seekToStart()
+        } else if time > seekableEnd {
+            // time is larger than possibly, so just move forward as far as possible
+            seekToLive()
+        }
+
+        updateNowPlayingInfoCenter()
+    }
+    
+    /**
+     Seeks forward as far as possible minus 5 seconds of buffer time
+     
+     */
+    public func seekToLive() {
+        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
+        let seekableEnd = seekableRange!.end.seconds
+        
+        let livePosition = seekableEnd - 5
+        
+        player?.seekToTime(CMTimeMake(Int64(livePosition), 1))
+        updateNowPlayingInfoCenter()
+    }
+
+    /**
+     Seeks backwards as far as possible. If the whole audio file
+     is seekable this will seek to the start of the file
+     
+     */
+    func seekToStart() {
+        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
+        let seekableStart = seekableRange!.start.seconds
+        
+        player?.seekToTime(CMTimeMake(Int64(seekableStart), 1))
         updateNowPlayingInfoCenter()
     }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -628,7 +628,11 @@ public class AudioPlayer: NSObject {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         let seekableEnd = seekableRange!.end.seconds
         
-        let livePosition = seekableEnd - 5
+        // ensure 5 seconds of buffer time is actually in range
+        let seekableDuration = seekableRange!.duration.seconds
+        let bufferTime = min(seekableDuration, 5)
+        
+        let livePosition = seekableEnd - bufferTime
         
         player?.seekToTime(CMTimeMake(Int64(livePosition), 1))
         updateNowPlayingInfoCenter()

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -645,9 +645,9 @@ public class AudioPlayer: NSObject {
      */
     func seekToStart() {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let seekableStart = seekableRange!.start.seconds
+        let seekableStart = seekableRange!.start
         
-        player?.seekToTime(CMTimeMake(Int64(seekableStart), 1))
+        player?.seekToTime(seekableStart)
         updateNowPlayingInfoCenter()
     }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -634,7 +634,7 @@ public class AudioPlayer: NSObject {
         updateNowPlayingInfoCenter()
     }
     
-    func getSeekableBordersWithBufferTime(bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
+    private func getSeekableBordersWithBufferTime(bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
 
         // set new end to current end minus buffer time. but do not move before start time

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -636,12 +636,8 @@ public class AudioPlayer: NSObject {
     
     private func getSeekableBordersWithBufferTime(bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-
-        // set new end to current end minus buffer time. but do not move before start time
         let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
-        // set new preferred start one second after start, but make sure it does not go over the end
         let earliesPoint = min(seekableRange!.end, seekableRange!.start + bufferTime)
-        
         return (earliesPoint, latestPoint)
     }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -626,19 +626,23 @@ public class AudioPlayer: NSObject {
      
      */
     public func seekToLive() {
-        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let bufferTime = CMTime(seconds: 5, preferredTimescale: 1000000000)
-        
-        // set new end to current end minus buffer time. but do not move before start time
-        let seekableEnd = min(seekableRange!.start, seekableRange!.end - bufferTime)
-        // set new preferred start one second after start, but make sure it does not go over the end
-        let seekableStart = max(seekableRange!.end, seekableRange!.start + CMTime(seconds: 1, preferredTimescale: 1000000000))
-
-        // ensure we do not seek before start time
-        let newPos = max(seekableStart, seekableEnd)
+        let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
+        let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
+        let newPos = max(earliesPoint, latestPoint)
         
         player?.seekToTime(newPos)
         updateNowPlayingInfoCenter()
+    }
+    
+    func getSeekableBordersWithBufferTime(bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
+        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
+
+        // set new end to current end minus buffer time. but do not move before start time
+        let latestPoint = min(seekableRange!.start, seekableRange!.end - bufferTime)
+        // set new preferred start one second after start, but make sure it does not go over the end
+        let earliesPoint = max(seekableRange!.end, seekableRange!.start + bufferTime)
+        
+        return (earliesPoint, latestPoint)
     }
 
     /**
@@ -646,16 +650,9 @@ public class AudioPlayer: NSObject {
      
      */
     func seekToStart() {
-        let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let bufferTime = CMTime(seconds: 5, preferredTimescale: 1000000000)
-        
-        // set new end to current end minus buffer time. but do not move before start time
-        let seekableEnd = min(seekableRange!.start, seekableRange!.end - bufferTime)
-        // set new preferred start one second after start, but make sure it does not go over the end
-        let seekableStart = max(seekableRange!.end, seekableRange!.start + CMTime(seconds: 1, preferredTimescale: 1000000000))
-        
-        // ensure we do not seek before start time
-        let newPos = min(seekableStart, seekableEnd)
+        let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
+        let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
+        let newPos = min(earliesPoint, latestPoint)
         
         player?.seekToTime(newPos)
         updateNowPlayingInfoCenter()

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -658,10 +658,21 @@ public class AudioPlayer: NSObject {
     private func getSeekableBordersWithBufferTime(var bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
         let marginBuffer = CMTime(seconds: 1, preferredTimescale: 1000000000)
         bufferTime = max(bufferTime, marginBuffer)
+        
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
-        let earliesPoint = min(seekableRange!.end, seekableRange!.start + marginBuffer)
-        return (earliesPoint, latestPoint)
+        if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
+            let latestPoint = max(seekableStart, seekableEnd - bufferTime)
+            let earliesPoint = min(seekableEnd, seekableStart + marginBuffer)
+            return (earliesPoint, latestPoint)
+        }
+        else if let currentTime = player?.currentTime() {
+            // if there is no start and end point of seekable range
+            // return the current time, so no seeking possible
+            return (currentTime, currentTime)
+        }
+        else {
+            // TODO: what should I do here?
+        }
     }
 
     /**

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -611,11 +611,11 @@ public class AudioPlayer: NSObject {
             }
             else if time < seekableStart {
                 // time is before seekable start, so just move to the most early position as possible
-                seekToStart()
+                seekToSeekableRangeStart()
             }
             else if time > seekableEnd {
                 // time is larger than possibly, so just move forward as far as possible
-                seekToLive()
+                seekToSeekableRangeEnd()
             }
             
             updateNowPlayingInfoCenter()
@@ -626,7 +626,7 @@ public class AudioPlayer: NSObject {
      Seeks forward as far as possible
      
      */
-    public func seekToLive() {
+    public func seekToSeekableRangeEnd() {
         let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
         let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
         let newPos = max(earliesPoint, latestPoint)
@@ -639,7 +639,7 @@ public class AudioPlayer: NSObject {
      Seeks backwards as far as possible.
      
      */
-    func seekToStart() {
+    public func seekToSeekableRangeStart() {
         let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
         let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
         let newPos = min(earliesPoint, latestPoint)

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -601,7 +601,7 @@ public class AudioPlayer: NSObject {
     - parameter time: The time to seek to.
     */
     public func seekToTime(time: NSTimeInterval) {
-        let time = CMTime(seconds: time, preferredTimescale: 1)
+        let time = CMTime(seconds: time, preferredTimescale: 600)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         let seekableStart = seekableRange!.start
         let seekableEnd = seekableRange!.end
@@ -622,20 +622,14 @@ public class AudioPlayer: NSObject {
     }
     
     /**
-     Seeks forward as far as possible minus 5 seconds of buffer time
+     Seeks forward as far as possible
      
      */
     public func seekToLive() {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let seekableEnd = seekableRange!.end.seconds
+        let seekableEnd = seekableRange!.end
         
-        // ensure 5 seconds of buffer time is actually in range
-        let seekableDuration = seekableRange!.duration.seconds
-        let bufferTime = min(seekableDuration, 5)
-        
-        let livePosition = seekableEnd - bufferTime
-        
-        player?.seekToTime(CMTimeMake(Int64(livePosition), 1))
+        player?.seekToTime(seekableEnd)
         updateNowPlayingInfoCenter()
     }
 
@@ -648,7 +642,7 @@ public class AudioPlayer: NSObject {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         let seekableStart = seekableRange!.start
         
-        player?.seekToTime(seekableStart)
+        player?.seekToTime(seekableStart, toleranceBefore: CMTime(seconds: 1, preferredTimescale: 1), toleranceAfter: CMTime(seconds: 1, preferredTimescale: 1))
         updateNowPlayingInfoCenter()
     }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -638,7 +638,7 @@ public class AudioPlayer: NSObject {
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
 
         // set new end to current end minus buffer time. but do not move before start time
-        let latestPoint = min(seekableRange!.start, seekableRange!.end - bufferTime)
+        let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
         // set new preferred start one second after start, but make sure it does not go over the end
         let earliesPoint = max(seekableRange!.end, seekableRange!.start + bufferTime)
         

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -610,10 +610,12 @@ public class AudioPlayer: NSObject {
         if time >= seekableStart && time <= seekableEnd {
             // time is in seekable range
             player?.seekToTime(time)
-        } else if time < seekableStart {
+        }
+        else if time < seekableStart {
             // time is before seekable start, so just move to the most early position as possible
             seekToStart()
-        } else if time > seekableEnd {
+        }
+        else if time > seekableEnd {
             // time is larger than possibly, so just move forward as far as possible
             seekToLive()
         }

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -601,14 +601,15 @@ public class AudioPlayer: NSObject {
     - parameter time: The time to seek to.
     */
     public func seekToTime(time: NSTimeInterval) {
+        let time = CMTime(seconds: time, preferredTimescale: 1)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
-        let seekableStart = seekableRange!.start.seconds
-        let seekableEnd = seekableRange!.end.seconds
+        let seekableStart = seekableRange!.start
+        let seekableEnd = seekableRange!.end
         
         // check if time is in seekable range
         if time >= seekableStart && time <= seekableEnd {
             // time is in seekable range
-            player?.seekToTime(CMTimeMake(Int64(time), 1))
+            player?.seekToTime(time)
         } else if time < seekableStart {
             // time is before seekable start, so just move to the most early position as possible
             seekToStart()

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -629,10 +629,11 @@ public class AudioPlayer: NSObject {
     public func seekToSeekableRangeEnd() {
         let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
         let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
-        let newPos = max(earliesPoint, latestPoint)
-        
-        player?.seekToTime(newPos)
-        updateNowPlayingInfoCenter()
+        if earliesPoint != nil && latestPoint != nil {
+            let newPos = max(earliesPoint!, latestPoint!)
+            player?.seekToTime(newPos)
+            updateNowPlayingInfoCenter()
+        }
     }
 
     /**
@@ -642,10 +643,11 @@ public class AudioPlayer: NSObject {
     public func seekToSeekableRangeStart() {
         let bufferTime = CMTime(seconds: 1, preferredTimescale: 1000000000)
         let (earliesPoint, latestPoint) = getSeekableBordersWithBufferTime(bufferTime)
-        let newPos = min(earliesPoint, latestPoint)
-        
-        player?.seekToTime(newPos)
-        updateNowPlayingInfoCenter()
+        if earliesPoint != nil && latestPoint != nil {
+            let newPos = min(earliesPoint!, latestPoint!)
+            player?.seekToTime(newPos)
+            updateNowPlayingInfoCenter()
+        }
     }
     
     /**
@@ -655,7 +657,7 @@ public class AudioPlayer: NSObject {
     - parameter bufferTime: set the margin buffer time of the latest point to the end of the actual
                             seekable range. A minimum of 1 second will be enforced.
     */
-    private func getSeekableBordersWithBufferTime(var bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
+    private func getSeekableBordersWithBufferTime(var bufferTime: CMTime) -> (earliesPoint: CMTime?, latestPoint: CMTime?) {
         let marginBuffer = CMTime(seconds: 1, preferredTimescale: 1000000000)
         bufferTime = max(bufferTime, marginBuffer)
         
@@ -671,7 +673,8 @@ public class AudioPlayer: NSObject {
             return (currentTime, currentTime)
         }
         else {
-            // TODO: what should I do here?
+            // can not seek at all, so return nil
+            return (nil, nil)
         }
     }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -647,6 +647,13 @@ public class AudioPlayer: NSObject {
         updateNowPlayingInfoCenter()
     }
     
+    /**
+     Returns the earliest and latest possible point of the current seekable range with a margin to
+     the actual borders of 1 second.
+
+    - parameter bufferTime: set the margin buffer time of the latest point to the end of the actual
+                            seekable range. A minimum of 1 second will be enforced.
+    */
     private func getSeekableBordersWithBufferTime(var bufferTime: CMTime) -> (earliesPoint: CMTime, latestPoint: CMTime) {
         let marginBuffer = CMTime(seconds: 1, preferredTimescale: 1000000000)
         bufferTime = max(bufferTime, marginBuffer)

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -640,7 +640,7 @@ public class AudioPlayer: NSObject {
         // set new end to current end minus buffer time. but do not move before start time
         let latestPoint = max(seekableRange!.start, seekableRange!.end - bufferTime)
         // set new preferred start one second after start, but make sure it does not go over the end
-        let earliesPoint = max(seekableRange!.end, seekableRange!.start + bufferTime)
+        let earliesPoint = min(seekableRange!.end, seekableRange!.start + bufferTime)
         
         return (earliesPoint, latestPoint)
     }


### PR DESCRIPTION
Currently seeking on a livestream crashes playback (nothing to hear anymore, no real code crash) if you seek to a time out of the seekable range. Therefore I added a range check to the `seek` method call.

I also added seekToLive() and seekToStart() as helpers. They are used by the default seek method if the time to seek to is out of range.

Currently seekToLive() seeks to the latest seekable posistion in the data stream minus 5 seconds of buffer time. The 5 seconds are quite randomly picked and should be changed to a the value of the buffer configuration which might be added in a future release.