### PR TITLE
Added tvOS support.

### DIFF
--- a/AudioPlayer/AudioPlayer tvOS/Info-tvOS.plist
+++ b/AudioPlayer/AudioPlayer tvOS/Info-tvOS.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/AudioPlayer/AudioPlayer.h
+++ b/AudioPlayer/AudioPlayer.h
@@ -1,0 +1,19 @@
+//
+//  AudioPlayer tvOS.h
+//  AudioPlayer tvOS
+//
+//  Created by Daniel Martín Prieto on 31/12/15.
+//  Copyright © 2015 Kevin Delannoy. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for AudioPlayer tvOS.
+FOUNDATION_EXPORT double AudioPlayer_tvOSVersionNumber;
+
+//! Project version string for AudioPlayer tvOS.
+FOUNDATION_EXPORT const unsigned char AudioPlayer_tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <AudioPlayer_tvOS/PublicHeader.h>
+
+

--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		462679681AED5DDC003771C9 /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
 		4626796A1AED5DE8003771C9 /* AudioItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679691AED5DE8003771C9 /* AudioItem.swift */; };
 		4669307A1BAD30AB00C1E97C /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
+		653E18891C354194003C0CAB /* AudioPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 653E18881C354194003C0CAB /* AudioPlayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		653E188A1C354194003C0CAB /* AudioPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 653E18881C354194003C0CAB /* AudioPlayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		653E188B1C3541B0003C0CAB /* AudioItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679691AED5DE8003771C9 /* AudioItem.swift */; };
+		653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
+		653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +36,9 @@
 		462679671AED5DDC003771C9 /* AudioPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
 		462679691AED5DE8003771C9 /* AudioItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioItem.swift; sourceTree = "<group>"; };
 		466930791BAD30AB00C1E97C /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		653E18801C353DD0003C0CAB /* AudioPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AudioPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		653E18841C353DD0003C0CAB /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		653E18881C354194003C0CAB /* AudioPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioPlayer.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,14 +57,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		653E187C1C353DD0003C0CAB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		462679331AED567D003771C9 = {
 			isa = PBXGroup;
 			children = (
+				653E18881C354194003C0CAB /* AudioPlayer.h */,
 				4626793F1AED567D003771C9 /* AudioPlayer */,
 				4626794C1AED567D003771C9 /* AudioPlayerTests */,
+				653E18811C353DD0003C0CAB /* AudioPlayer tvOS */,
 				4626793E1AED567D003771C9 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -66,6 +83,7 @@
 			children = (
 				4626793D1AED567D003771C9 /* AudioPlayer.framework */,
 				462679481AED567D003771C9 /* AudioPlayerTests.xctest */,
+				653E18801C353DD0003C0CAB /* AudioPlayer.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -105,6 +123,14 @@
 			path = supporting_files;
 			sourceTree = "<group>";
 		};
+		653E18811C353DD0003C0CAB /* AudioPlayer tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				653E18841C353DD0003C0CAB /* Info-tvOS.plist */,
+			);
+			path = "AudioPlayer tvOS";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -112,6 +138,15 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				653E18891C354194003C0CAB /* AudioPlayer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653E187D1C353DD0003C0CAB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				653E188A1C354194003C0CAB /* AudioPlayer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,6 +189,24 @@
 			productReference = 462679481AED567D003771C9 /* AudioPlayerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		653E187F1C353DD0003C0CAB /* AudioPlayer tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 653E18871C353DD0003C0CAB /* Build configuration list for PBXNativeTarget "AudioPlayer tvOS" */;
+			buildPhases = (
+				653E187B1C353DD0003C0CAB /* Sources */,
+				653E187C1C353DD0003C0CAB /* Frameworks */,
+				653E187D1C353DD0003C0CAB /* Headers */,
+				653E187E1C353DD0003C0CAB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "AudioPlayer tvOS";
+			productName = "AudioPlayer tvOS";
+			productReference = 653E18801C353DD0003C0CAB /* AudioPlayer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -171,6 +224,9 @@
 					462679471AED567D003771C9 = {
 						CreatedOnToolsVersion = 6.3.1;
 					};
+					653E187F1C353DD0003C0CAB = {
+						CreatedOnToolsVersion = 7.2;
+					};
 				};
 			};
 			buildConfigurationList = 462679371AED567D003771C9 /* Build configuration list for PBXProject "AudioPlayer" */;
@@ -187,6 +243,7 @@
 			targets = (
 				4626793C1AED567D003771C9 /* AudioPlayer */,
 				462679471AED567D003771C9 /* AudioPlayerTests */,
+				653E187F1C353DD0003C0CAB /* AudioPlayer tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -200,6 +257,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		462679461AED567D003771C9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653E187E1C353DD0003C0CAB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -223,6 +287,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653E187B1C353DD0003C0CAB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				653E188B1C3541B0003C0CAB /* AudioItem.swift in Sources */,
+				653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */,
+				653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -386,6 +460,45 @@
 			};
 			name = Release;
 		};
+		653E18851C353DD0003C0CAB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/AudioPlayer tvOS/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = be.delannoyk.AudioPlayer;
+				PRODUCT_NAME = AudioPlayer;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		653E18861C353DD0003C0CAB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/AudioPlayer tvOS/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = be.delannoyk.AudioPlayer;
+				PRODUCT_NAME = AudioPlayer;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -415,6 +528,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		653E18871C353DD0003C0CAB /* Build configuration list for PBXNativeTarget "AudioPlayer tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				653E18851C353DD0003C0CAB /* Debug */,
+				653E18861C353DD0003C0CAB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AudioPlayer/AudioPlayer.xcodeproj/xcshareddata/xcschemes/AudioPlayer tvOS.xcscheme
+++ b/AudioPlayer/AudioPlayer.xcodeproj/xcshareddata/xcschemes/AudioPlayer tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "653E187F1C353DD0003C0CAB"
+               BuildableName = "AudioPlayer.framework"
+               BlueprintName = "AudioPlayer tvOS"
+               ReferencedContainer = "container:AudioPlayer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "653E187F1C353DD0003C0CAB"
+            BuildableName = "AudioPlayer.framework"
+            BlueprintName = "AudioPlayer tvOS"
+            ReferencedContainer = "container:AudioPlayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "653E187F1C353DD0003C0CAB"
+            BuildableName = "AudioPlayer.framework"
+            BlueprintName = "AudioPlayer tvOS"
+            ReferencedContainer = "container:AudioPlayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -745,10 +745,11 @@ public class AudioPlayer: NSObject {
             if let trackNumber = currentItem.trackNumber {
                 info[MPMediaItemPropertyAlbumTrackNumber] = trackNumber
             }
-            if let artwork = currentItem.artworkImage {
-                info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(image: artwork)
-            }
-
+            #if os(iOS)
+                if let artwork = currentItem.artworkImage {
+                    info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(image: artwork)
+                }
+            #endif
             if let duration = currentItemDuration {
                 info[MPMediaItemPropertyPlaybackDuration] = duration
             }


### PR DESCRIPTION
Hey, I love this project, thanks for the work you've done. I'd like to start contributing. I've added support for tvOS, creating a new target. The bundle identifier and the product name are the same as in the iOS version as I saw in other libraries as Alamofire.

I'm using AudioPlayer in my TV project from this branch using Carthage, so maybe you can check if the iOS target also works with it and add the compatibility to the readme.

Also, it'd be great if someone can update the podspec adding tvOS support and release a new version.