### PR TITLE
Allow specifying before & after tolerance on seek

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -716,7 +716,7 @@ public class AudioPlayer: NSObject {
 
     - parameter time: The time to seek to.
     */
-    public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimeZero, toleranceAfter: CMTime = kCMTimeZero) {
+    public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimePositiveInfinity, toleranceAfter: CMTime = kCMTimePositiveInfinity) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -716,14 +716,14 @@ public class AudioPlayer: NSObject {
 
     - parameter time: The time to seek to.
     */
-    public func seekToTime(time: NSTimeInterval) {
+    public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimeZero, toleranceAfter: CMTime = kCMTimeZero) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
             // check if time is in seekable range
             if time >= seekableStart && time <= seekableEnd {
                 // time is in seekable range
-                player?.seekToTime(time)
+                player?.seekToTime(time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
             }
             else if time < seekableStart {
                 // time is before seekable start, so just move to the most early position as possible


### PR DESCRIPTION
Updated seekToTime with a non-breaking source change that optionally allows you to specify beforeTolerance and afterTolerance as 2nd & third arguments. Current calls to seekToTime will all work and behave exactly as before as I've set the defaults to kCMTimePositiveInfinity, which the documentation states is equivalent to calling seekToTime: directly.