### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ AudioPlayer
 ===========
 [![Build Status](https://travis-ci.org/delannoyk/AudioPlayer.svg)](https://travis-ci.org/delannoyk/AudioPlayer)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-![Cocoapods Compatible](https://img.shields.io/cocoapods/v/KDEAudioPlayer.svg)
+![CocoaPods Compatible](https://img.shields.io/cocoapods/v/KDEAudioPlayer.svg)
 ![Platform iOS | tvOS](https://img.shields.io/badge/platform-iOS%20%7C%20tvOS%20%7C%20OSX-lightgrey.svg)
 [![Contact](https://img.shields.io/badge/contact-%40kdelannoy-blue.svg)](https://twitter.com/kdelannoy)
 
@@ -17,7 +17,7 @@ AudioPlayer is a wrapper around AVPlayer. It also offers cool features such as:
 
 ## Installation
 
-* Cocoapods: `pod 'KDEAudioPlayer'`
+* CocoaPods: `pod 'KDEAudioPlayer'`
 * Carthage: `github "delannoyk/AudioPlayer"`
 
 ## Usage


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
