### PR TITLE
force exact seeking when zero before/after seek tolerance is specified

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -1139,6 +1139,10 @@ public class AudioPlayer: NSObject {
         if mode.intersect(.Repeat) != [] {
             seekToTime(0)
             resume()
+            
+            if let currentItem = self.currentItem {
+                delegate?.audioPlayer(self, willStartPlayingItem: currentItem)
+            }
         }
         else if hasNext() {
             next()

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -731,6 +731,12 @@ public class AudioPlayer: NSObject {
     */
     public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimePositiveInfinity, toleranceAfter: CMTime = kCMTimePositiveInfinity) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
+        // if we specify non-default zero tolerance, skip the range checks: will take longer to play, but necessary for when seek needs to be precise 
+        if toleranceBefore == kCMTimeZero && toleranceAfter == kCMTimeZero {
+            player?.seekToTime(time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
+            return
+        }
+        
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
             // check if time is in seekable range


### PR DESCRIPTION
We were having some issues with the code not seeking exactly when we needed exact seeking (toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero) because the player?.seekToTime(_:toleranceBefore:toleranceAfter:) was hidden away in a few conditional calls and never reached when we needed exact seeking. This appears to fix it while preserving your existing performance enhancements for when exact seeking is not crucial. 