### PR TITLE
Fix resuming of playback after pausing in lockscreen

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -423,11 +423,13 @@ public class AudioPlayer: NSObject {
 
                 if reachability.isReachable() || URLInfo.URL.isOfflineURL {
                     state = .Buffering
+                    beginBackgroundTask()
                 }
                 else {
                     connectionLossDate = NSDate()
                     stateWhenConnectionLost = .Buffering
                     state = .WaitingForConnection
+                    beginBackgroundTask()
                     return
                 }
 

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -914,7 +914,9 @@ public class AudioPlayer: NSObject {
 
                     stateBeforeBuffering = state
                     if reachability.isReachable() || (currentItem?.soundURLs[currentQuality ?? defaultQuality]?.isOfflineURL ?? false) {
-                        state = .Buffering
+                        if state != .Paused { // Fixes issue https://github.com/delannoyk/AudioPlayer/issues/44
+                            state = .Buffering
+                        }
                     }
                     else {
                         state = .WaitingForConnection

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -1077,7 +1077,7 @@ public class AudioPlayer: NSObject {
     - parameter time: The current time.
     */
     private func currentProgressionUpdated(time: CMTime) {
-        if let currentItemProgression = currentItemProgression, currentItemDuration = currentItemDuration where currentItemDuration > 0 {
+        if let currentItemProgression = currentItemProgression, currentItemDuration = currentItemDuration, currentItem = player?.currentItem where currentItemDuration > 0 && currentItem.playbackLikelyToKeepUp {
             //This fixes the behavior where sometimes the `playbackLikelyToKeepUp`
             //isn't changed even though it's playing (happens mostly at the first play though).
             if state == .Buffering || state == .Paused {

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -410,6 +410,9 @@ public class AudioPlayer: NSObject {
                 player?.rate = 0
                 player = nil
 
+                stateBeforeBuffering = nil
+                stateWhenConnectionLost = nil
+
                 let URLInfo: AudioItemURL = {
                     switch (self.currentQuality ?? self.defaultQuality) {
                     case .High:
@@ -746,6 +749,8 @@ public class AudioPlayer: NSObject {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
+            stateBeforeBuffering = nil
+            stateWhenConnectionLost = nil
             // check if time is in seekable range
             if time >= seekableStart && time <= seekableEnd {
                 // time is in seekable range
@@ -771,6 +776,8 @@ public class AudioPlayer: NSObject {
      */
     public func seekToSeekableRangeEnd(padding: NSTimeInterval) {
         if let range = currentItemSeekableRange {
+            stateBeforeBuffering = nil
+            stateWhenConnectionLost = nil
             let position = max(range.earliest, range.latest - padding)
 
             let time = CMTime(seconds: position, preferredTimescale: 1000000000)
@@ -782,11 +789,13 @@ public class AudioPlayer: NSObject {
 
     /**
      Seeks backwards as far as possible.
-     
+
      - parameter padding: The padding to apply if any.
      */
     public func seekToSeekableRangeStart(padding: NSTimeInterval) {
         if let range = currentItemSeekableRange {
+            stateBeforeBuffering = nil
+            stateWhenConnectionLost = nil
             let position = min(range.latest, range.earliest + padding)
 
             let time = CMTime(seconds: position, preferredTimescale: 1000000000)

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -1079,7 +1079,7 @@ public class AudioPlayer: NSObject {
     - parameter time: The current time.
     */
     private func currentProgressionUpdated(time: CMTime) {
-        if let currentItemProgression = currentItemProgression, currentItemDuration = currentItemDuration, currentItem = player?.currentItem where currentItemDuration > 0 && currentItem.playbackLikelyToKeepUp {
+        if let currentItemProgression = currentItemProgression, currentItemDuration = currentItemDuration, currentItem = player?.currentItem where currentItemDuration > 0 && currentItem.status == .ReadyToPlay {
             //This fixes the behavior where sometimes the `playbackLikelyToKeepUp`
             //isn't changed even though it's playing (happens mostly at the first play though).
             if state == .Buffering || state == .Paused {

--- a/KDEAudioPlayer.podspec
+++ b/KDEAudioPlayer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'KDEAudioPlayer'
-  s.version       = '0.8.3'
+  s.version       = '0.8.4'
   s.license       =  { :type => 'MIT' }
   s.homepage      = 'https://github.com/delannoyk/AudioPlayer'
   s.authors       = { 'Kevin Delannoy' => 'delannoyk@gmail.com' }

--- a/KDEAudioPlayer.podspec
+++ b/KDEAudioPlayer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'KDEAudioPlayer'
-  s.version       = '0.8.2'
+  s.version       = '0.8.3'
   s.license       =  { :type => 'MIT' }
   s.homepage      = 'https://github.com/delannoyk/AudioPlayer'
   s.authors       = { 'Kevin Delannoy' => 'delannoyk@gmail.com' }


### PR DESCRIPTION
Fixes #44 

Please have a look at this and let me know what you think. I tested it and it works for me but I'm unsure weather it might break something else.

What I don't fully understand is why the properties `playbackLikelyToKeepUp` and `playbackBufferEmpty` on the `currentItem` both change. It seem like this happens when the app gets killed from the background? I couldn't find a place in your library that might trigger this. Or did I miss something?