### PR TITLE
Allow user's choice of whether to respect seekable time ranges when seeking 

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -762,12 +762,12 @@ public class AudioPlayer: NSObject {
                     // time is larger than possibly, so just move forward as far as possible
                     seekToSeekableRangeEnd(1)
                 }
-                
-                updateNowPlayingInfoCenter()
             }
         } else {
             player?.seekToTime(time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
         }
+        
+        updateNowPlayingInfoCenter()
     }
     
     /**

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -744,6 +744,12 @@ public class AudioPlayer: NSObject {
     */
     public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimePositiveInfinity, toleranceAfter: CMTime = kCMTimePositiveInfinity) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
+        // if we specify non-default zero tolerance, skip the range checks: will take longer to play, but necessary for when seek needs to be precise 
+        if toleranceBefore == kCMTimeZero && toleranceAfter == kCMTimeZero {
+            player?.seekToTime(time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
+            return
+        }
+        
         let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
         if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
             // check if time is in seekable range

--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -742,11 +742,11 @@ public class AudioPlayer: NSObject {
 
     - parameter time: The time to seek to.
     */
-    public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimePositiveInfinity, toleranceAfter: CMTime = kCMTimePositiveInfinity, respectingSeekableTimeRanges: Bool = true) {
+    public func seekToTime(time: NSTimeInterval, toleranceBefore: CMTime = kCMTimePositiveInfinity, toleranceAfter: CMTime = kCMTimePositiveInfinity, adaptingTimeToSeekableTimeRanges adaptTime: Bool = true) {
         let time = CMTime(seconds: time, preferredTimescale: 1000000000)
         
         // if we specify non-default zero tolerance, skip the range checks: will take longer to play, but necessary for when seek needs to be precise
-        if respectingSeekableTimeRanges {
+        if adaptTime {
             let seekableRange = player?.currentItem?.seekableTimeRanges.last?.CMTimeRangeValue
             if let seekableStart = seekableRange?.start, let seekableEnd = seekableRange?.end {
                 // check if time is in seekable range


### PR DESCRIPTION
If you pass `adaptingTimeToSeekableTimeRanges: false`, the player will ignore currently seekable time ranges and instead force exact seeking, which may take longer but will be more reliable. This is an evolution of #41 (submitted another PR because I had made other changes on my fork's master branch).