### PR TITLE
Notify delegate of willStartPlayingAudioItem: when repeating an audio item

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -1147,6 +1147,10 @@ public class AudioPlayer: NSObject {
         if mode.intersect(.Repeat) != [] {
             seekToTime(0)
             resume()
+            
+            if let currentItem = self.currentItem {
+                delegate?.audioPlayer(self, willStartPlayingItem: currentItem)
+            }
         }
         else if hasNext() {
             next()


### PR DESCRIPTION
Rationale: In our production app, we use AudioPlayer in .Repeat mode because if we do not, then as soon as playback reaches the end, the media item is stopped and we have to re-create it. However, we still want playback to pause when it reaches the end, so this is a tweak we included that makes such a thing possible.

It could theoretically be a breaking change in rare cases, so maybe check with the developer community before accepting, or alternatively make sure this coincides with a major version update (bump 0.8.x => 0.9.x). If you decide not to include it, I understand. We would then continue to maintain a fork with the patch until we found time to implement a hackaround on our end :)