### PR TITLE
% fixed currentItemIndexInQueue value after removal of item from queue

### DIFF
--- a/AudioPlayer/AudioPlayer/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/AudioPlayer.swift
@@ -648,6 +648,9 @@ public class AudioPlayer: NSObject {
         if let enqueuedItems = enqueuedItems {
             if index >= 0 && index < enqueuedItems.count {
                 self.enqueuedItems?.removeAtIndex(index)
+                if index < currentItemIndexInQueue {
+                    currentItemIndexInQueue = currentItemIndexInQueue! - 1
+                }
             }
         }
     }


### PR DESCRIPTION
when an item is removed from an index lower than the current playing one, the currentItemIndexInQueue was not being updated accordingly.