### PR TITLE
Adding a way to disable items in the queue

### DIFF
--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -21,6 +21,20 @@ private extension Array {
     }
 }
 
+// MARK: - AudioItemQueueDelegate
+
+/// `AudioItemQueueDelegate` defines the behavior of `AudioItem` in certain circumstances and is notified upon notable 
+/// events.
+protocol AudioItemQueueDelegate: class {
+    /// Returns a boolean value indicating whether an item should be consider playable in the queue.
+    ///
+    /// - Parameters:
+    ///   - queue: The queue.
+    ///   - item: The item we ask the information for.
+    /// - Returns: A boolean value indicating whether an item should be consider playable in the queue.
+    func audioItemQueue(_ queue: AudioItemQueue, shouldConsiderItem item: AudioItem) -> Bool
+}
+
 // MARK: - AudioItemQueue
 
 /// `AudioItemQueue` handles queueing items with a playing mode.
@@ -43,6 +57,9 @@ class AudioItemQueue {
             adaptQueue(oldMode: oldValue)
         }
     }
+
+    /// The queue delegate.
+    weak var delegate: AudioItemQueueDelegate?
 
     /// Initializes a queue with a list of items and the mode.
     ///

--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -92,8 +92,7 @@ class AudioItemQueue {
             return
         }
 
-        if oldMode.contains(.repeat) && !mode.contains(.repeat) &&
-            historic.last == queue[nextPosition] {
+        if oldMode.contains(.repeat) && !mode.contains(.repeat) && historic.last == queue[nextPosition] {
             nextPosition += 1
         }
         if oldMode.contains(.shuffle) && !mode.contains(.shuffle) {

--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -39,10 +39,10 @@ protocol AudioItemQueueDelegate: class {
 
 /// `AudioItemQueue` handles queueing items with a playing mode.
 class AudioItemQueue {
-    /// <#Description#>
+    /// The errors that can be thrown from `nextItem()` and `previousItem()`.
     ///
-    /// - currentItemConsideredUnplayable: <#currentItemConsideredUnplayable description#>
-    /// - noPlayableItemsInQueue: <#noPlayableItemsInQueue description#>
+    /// - currentItemConsideredUnplayable: The item that should be played is considered unplayable.
+    /// - noPlayableItemsInQueue: None of the items in the queue are considered playable.
     enum QueueError: Error {
         case currentItemConsideredUnplayable
         case noPlayableItemsInQueue

--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -200,4 +200,11 @@ class AudioItemQueue {
             items.remove(at: index)
         }
     }
+
+    /// Returns a boolean value indicating whether an item should be consider playable in the queue.
+    ///
+    /// - Returns: A boolean value indicating whether an item should be consider playable in the queue.
+    private func shouldConsiderItem(item: AudioItem) -> Bool {
+        return delegate?.audioItemQueue(self, shouldConsiderItem: item) ?? true
+    }
 }

--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -39,6 +39,15 @@ protocol AudioItemQueueDelegate: class {
 
 /// `AudioItemQueue` handles queueing items with a playing mode.
 class AudioItemQueue {
+    /// <#Description#>
+    ///
+    /// - currentItemConsideredUnplayable: <#currentItemConsideredUnplayable description#>
+    /// - noPlayableItemsInQueue: <#noPlayableItemsInQueue description#>
+    enum QueueError: Error {
+        case currentItemConsideredUnplayable
+        case noPlayableItemsInQueue
+    }
+
     /// The original items, keeping the same order.
     private(set) var items: [AudioItem]
 
@@ -110,7 +119,7 @@ class AudioItemQueue {
     /// Returns the next item in the queue.
     ///
     /// - Returns: The next item in the queue.
-    func nextItem() -> AudioItem? {
+    func nextItem() throws -> AudioItem? {
         //Early exit if queue is empty
         guard !queue.isEmpty else {
             return nil
@@ -127,7 +136,7 @@ class AudioItemQueue {
 
         if mode.contains(.repeatAll) {
             nextPosition = 0
-            return nextItem()
+            return try nextItem()
         }
         return nil
     }
@@ -144,7 +153,7 @@ class AudioItemQueue {
     /// Returns the previous item in the queue.
     ///
     /// - Returns: The previous item in the queue.
-    func previousItem() -> AudioItem? {
+    func previousItem() throws -> AudioItem? {
         //Early exit if queue is empty
         guard !queue.isEmpty else {
             return nil
@@ -168,7 +177,7 @@ class AudioItemQueue {
 
         if mode.contains(.repeatAll) {
             nextPosition = queue.count + 1
-            return previousItem()
+            return try previousItem()
         }
         return nil
     }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerDelegate.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerDelegate.swift
@@ -23,6 +23,14 @@ public protocol AudioPlayerDelegate: class {
     ///   - state: The new state.
     func audioPlayer(_ audioPlayer: AudioPlayer, didChangeStateFrom from: AudioPlayerState, to state: AudioPlayerState)
 
+    /// This method is called to ensure an item should be played or not. Default implementation returns `true`.
+    ///
+    /// - Parameters:
+    ///   - audioPlayer: The audio player.
+    ///   - item: The item that is waiting to be played.
+    /// - Returns: A boolean value indicating whether the player should start playing the item or not.
+    func audioPlayer(_ audioPlayer: AudioPlayer, shouldStartPlaying item: AudioItem) -> Bool
+
     /// This method is called when the audio player is about to start playing a new item.
     ///
     /// - Parameters:
@@ -68,15 +76,25 @@ public protocol AudioPlayerDelegate: class {
 
 public extension AudioPlayerDelegate {
     func audioPlayer(_ audioPlayer: AudioPlayer, didChangeStateFrom from: AudioPlayerState,
-                     to state: AudioPlayerState) {}
+                     to state: AudioPlayerState) {
+    }
 
-    func audioPlayer(_ audioPlayer: AudioPlayer, willStartPlaying item: AudioItem) {}
+    func audioPlayer(_ audioPlayer: AudioPlayer, shouldStartPlaying item: AudioItem) -> Bool {
+        return true
+    }
 
-    func audioPlayer(_ audioPlayer: AudioPlayer, didUpdateProgressionTo time: TimeInterval, percentageRead: Float) {}
+    func audioPlayer(_ audioPlayer: AudioPlayer, willStartPlaying item: AudioItem) {
+    }
 
-    func audioPlayer(_ audioPlayer: AudioPlayer, didFindDuration duration: TimeInterval, for item: AudioItem) {}
+    func audioPlayer(_ audioPlayer: AudioPlayer, didUpdateProgressionTo time: TimeInterval, percentageRead: Float) {
+    }
 
-    func audioPlayer(_ audioPlayer: AudioPlayer, didUpdateEmptyMetadataOn item: AudioItem, withData data: Metadata) {}
+    func audioPlayer(_ audioPlayer: AudioPlayer, didFindDuration duration: TimeInterval, for item: AudioItem) {
+    }
 
-    func audioPlayer(_ audioPlayer: AudioPlayer, didLoad range: TimeRange, for item: AudioItem) {}
+    func audioPlayer(_ audioPlayer: AudioPlayer, didUpdateEmptyMetadataOn item: AudioItem, withData data: Metadata) {
+    }
+
+    func audioPlayer(_ audioPlayer: AudioPlayer, didLoad range: TimeRange, for item: AudioItem) {
+    }
 }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerState.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerState.swift
@@ -12,9 +12,13 @@ import Foundation
 ///
 /// - maximumRetryCountHit: The player hit the maximum retry count.
 /// - foundationError: The `AVPlayer` failed to play.
+/// - itemNotConsideredPlayable: The current item that should be played is considered unplayable.
+/// - noItemsConsideredPlayable: The queue doesn't contain any item that is considered playable.
 public enum AudioPlayerError: Error {
     case maximumRetryCountHit
     case foundationError(Error)
+    case itemNotConsideredPlayable
+    case noItemsConsideredPlayable
 }
 
 /// `AudioPlayerState` defines 4 state an `AudioPlayer` instance can be in.

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
@@ -55,38 +55,26 @@ extension AudioPlayer {
 
     /// Plays previous item in the queue or rewind current item.
     public func previous() {
-        do {
-            if let previousItem = try queue?.previousItem() {
-                currentItem = previousItem
-            } else {
-                seek(to: 0)
-            }
-        } catch {
-            //TODO: handle queue error
+        if let previousItem = queue?.previousItem() {
+            currentItem = previousItem
+        } else {
+            seek(to: 0)
         }
     }
 
     /// Plays next item in the queue.
     public func next() {
-        do {
-            if let nextItem = try queue?.nextItem() {
-                currentItem = nextItem
-            }
-        } catch {
-            //TODO: handle queue error
+        if let nextItem = queue?.nextItem() {
+            currentItem = nextItem
         }
     }
 
     /// Plays the next item in the queue and if there isn't, the player will stop.
     public func nextOrStop() {
-        do {
-            if let nextItem = try queue?.nextItem() {
-                currentItem = nextItem
-            } else {
-                stop()
-            }
-        } catch {
-            //TODO: handle queue error
+        if let nextItem = queue?.nextItem() {
+            currentItem = nextItem
+        } else {
+            stop()
         }
     }
 

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
@@ -55,26 +55,38 @@ extension AudioPlayer {
 
     /// Plays previous item in the queue or rewind current item.
     public func previous() {
-        if let previousItem = queue?.previousItem() {
-            currentItem = previousItem
-        } else {
-            seek(to: 0)
+        do {
+            if let previousItem = try queue?.previousItem() {
+                currentItem = previousItem
+            } else {
+                seek(to: 0)
+            }
+        } catch {
+            //TODO: handle queue error
         }
     }
 
     /// Plays next item in the queue.
     public func next() {
-        if let nextItem = queue?.nextItem() {
-            currentItem = nextItem
+        do {
+            if let nextItem = try queue?.nextItem() {
+                currentItem = nextItem
+            }
+        } catch {
+            //TODO: handle queue error
         }
     }
 
     /// Plays the next item in the queue and if there isn't, the player will stop.
     public func nextOrStop() {
-        if let nextItem = queue?.nextItem() {
-            currentItem = nextItem
-        } else {
-            stop()
+        do {
+            if let nextItem = try queue?.nextItem() {
+                currentItem = nextItem
+            } else {
+                stop()
+            }
+        } catch {
+            //TODO: handle queue error
         }
     }
 

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
@@ -55,8 +55,8 @@ extension AudioPlayer {
 
     /// Plays previous item in the queue or rewind current item.
     public func previous() {
-        if hasPrevious {
-            currentItem = queue?.previousItem()
+        if let previousItem = queue?.previousItem() {
+            currentItem = previousItem
         } else {
             seek(to: 0)
         }
@@ -64,15 +64,15 @@ extension AudioPlayer {
 
     /// Plays next item in the queue.
     public func next() {
-        if hasNext {
-            currentItem = queue?.nextItem()
+        if let nextItem = queue?.nextItem() {
+            currentItem = nextItem
         }
     }
 
     /// Plays the next item in the queue and if there isn't, the player will stop.
     public func nextOrStop() {
-        if hasNext {
-            next()
+        if let nextItem = queue?.nextItem() {
+            currentItem = nextItem
         } else {
             stop()
         }

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
@@ -46,7 +46,11 @@ extension AudioPlayer {
             if let realIndex = queue?.queue.index(of: items[index]) {
                 queue?.nextPosition = realIndex
             }
-            currentItem = queue?.nextItem()
+            do {
+                currentItem = try queue?.nextItem()
+            } catch {
+                //TODO: handle queue error
+            }
         } else {
             stop()
             queue = nil

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
@@ -42,6 +42,7 @@ extension AudioPlayer {
     public func play(items: [AudioItem], startAtIndex index: Int = 0) {
         if !items.isEmpty {
             queue = AudioItemQueue(items: items, mode: mode)
+            queue?.delegate = self
             if let realIndex = queue?.queue.index(of: items[index]) {
                 queue?.nextPosition = realIndex
             }
@@ -77,5 +78,17 @@ extension AudioPlayer {
     /// - Parameter index: The index of the item to remove.
     public func removeItem(at index: Int) {
         queue?.remove(at: index)
+    }
+}
+
+extension AudioPlayer: AudioItemQueueDelegate {
+    /// Returns a boolean value indicating whether an item should be consider playable in the queue.
+    ///
+    /// - Parameters:
+    ///   - queue: The queue.
+    ///   - item: The item we ask the information for.
+    /// - Returns: A boolean value indicating whether an item should be consider playable in the queue.
+    func audioItemQueue(_ queue: AudioItemQueue, shouldConsiderItem item: AudioItem) -> Bool {
+        return delegate?.audioPlayer(self, shouldStartPlaying: item) ?? true
     }
 }

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
@@ -46,11 +46,7 @@ extension AudioPlayer {
             if let realIndex = queue?.queue.index(of: items[index]) {
                 queue?.nextPosition = realIndex
             }
-            do {
-                currentItem = try queue?.nextItem()
-            } catch {
-                //TODO: handle queue error
-            }
+            currentItem = queue?.nextItem()
         } else {
             stop()
             queue = nil

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -55,13 +55,13 @@ class AudioItemQueue_Tests: XCTestCase {
 
     func testQueueInNormalModelAfterSwitchingIfFromRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
-        _ = try! queue.nextItem()
+        XCTAssertNotNil(try! queue.nextItem())
 
         queue.mode = .normal
         XCTAssert((try! queue.nextItem()) === item2)
 
         let queue2 = AudioItemQueue(items: [item1], mode: .repeat)
-        _ = try! queue2.nextItem()
+        XCTAssertNotNil(try! queue2.nextItem())
 
         queue2.mode = .normal
         XCTAssert((try! queue2.nextItem()) === nil)
@@ -108,22 +108,22 @@ class AudioItemQueue_Tests: XCTestCase {
     func testHasNextItemInQueue() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: [.normal])
         XCTAssert(queue.hasNextItem)
-        _ = try! queue.nextItem()
+        XCTAssertNotNil(try! queue.nextItem())
         XCTAssert(queue.hasNextItem)
-        _ = try! queue.nextItem()
+        XCTAssertNotNil(try! queue.nextItem())
         XCTAssert(queue.hasNextItem)
-        _ = try! queue.nextItem()
+        XCTAssertNotNil(try! queue.nextItem())
         XCTAssertFalse(queue.hasNextItem)
 
         queue.mode = .repeat
         for _ in 0...100 {
-            _ = try! queue.nextItem()
+            XCTAssertNotNil(try! queue.nextItem())
             XCTAssert(queue.hasNextItem)
         }
 
         queue.mode = .repeatAll
         for _ in 0...100 {
-            _ = try! queue.nextItem()
+            XCTAssertNotNil(try! queue.nextItem())
             XCTAssert(queue.hasNextItem)
         }
 
@@ -140,7 +140,7 @@ class AudioItemQueue_Tests: XCTestCase {
         XCTAssertFalse(queue.hasPreviousItem)
         XCTAssertNil(try! queue.previousItem())
 
-        _ = try! queue.nextItem()
+        XCTAssertNotNil(try! queue.nextItem())
         XCTAssert(queue.hasNextItem)
         XCTAssert((try! queue.previousItem()) === item1)
     }

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -16,16 +16,16 @@ class AudioItemQueue_Tests: XCTestCase {
 
     func testEmptyQueueGivesNilAsNextItem() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssert((try! queue.nextItem()) === nil)
+        XCTAssert((try queue.nextItem()) === nil)
     }
 
     func testQueueInNormalModeAndHistoric() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
-        XCTAssert((try! queue.nextItem()) === item1)
-        XCTAssert((try! queue.nextItem()) === item2)
-        XCTAssert((try! queue.nextItem()) === item3)
-        XCTAssert((try! queue.nextItem()) === nil)
-        XCTAssert((try! queue.nextItem()) === nil)
+        XCTAssert((try queue.nextItem()) === item1)
+        XCTAssert((try queue.nextItem()) === item2)
+        XCTAssert((try queue.nextItem()) === item3)
+        XCTAssert((try queue.nextItem()) === nil)
+        XCTAssert((try queue.nextItem()) === nil)
 
         XCTAssertEqual(queue.historic.count, 3)
         XCTAssert(queue.historic[0] === item1)
@@ -40,40 +40,40 @@ class AudioItemQueue_Tests: XCTestCase {
     func testQueueInRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
         for _ in 0...100 {
-            XCTAssert((try! queue.nextItem()) === item1)
+            XCTAssert((try queue.nextItem()) === item1)
         }
     }
 
     func testQueueInRepeatAllMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeatAll)
         for _ in 0...100 {
-            XCTAssert((try! queue.nextItem()) === item1)
-            XCTAssert((try! queue.nextItem()) === item2)
-            XCTAssert((try! queue.nextItem()) === item3)
+            XCTAssert((try queue.nextItem()) === item1)
+            XCTAssert((try queue.nextItem()) === item2)
+            XCTAssert((try queue.nextItem()) === item3)
         }
     }
 
     func testQueueInNormalModelAfterSwitchingIfFromRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
-        XCTAssertNotNil(try! queue.nextItem())
+        XCTAssertNotNil(try queue.nextItem())
 
         queue.mode = .normal
-        XCTAssert((try! queue.nextItem()) === item2)
+        XCTAssert((try queue.nextItem()) === item2)
 
         let queue2 = AudioItemQueue(items: [item1], mode: .repeat)
-        XCTAssertNotNil(try! queue2.nextItem())
+        XCTAssertNotNil(try queue2.nextItem())
 
         queue2.mode = .normal
-        XCTAssert((try! queue2.nextItem()) === nil)
+        XCTAssert((try queue2.nextItem()) === nil)
     }
 
     func testQueueInShuffleModeAfterSwitchingItFromNormalMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
-        XCTAssert((try! queue.nextItem()) === item1)
+        XCTAssert((try queue.nextItem()) === item1)
 
         queue.mode = .shuffle
         for _ in 0...100 {
-            XCTAssert((try! queue.nextItem()) !== item1)
+            XCTAssert((try queue.nextItem()) !== item1)
         }
         queue.nextPosition = 0
         queue.mode = .normal
@@ -84,7 +84,7 @@ class AudioItemQueue_Tests: XCTestCase {
         let item = try! queue.nextItem()
 
         for _ in 0...100 {
-            XCTAssert(try! queue.nextItem() === item)
+            XCTAssert(try queue.nextItem() === item)
         }
     }
 
@@ -100,30 +100,30 @@ class AudioItemQueue_Tests: XCTestCase {
 
     func testAdaptModeWhenQueueIsEmpty() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssertEqual(try! queue.nextItem(), nil)
+        XCTAssertEqual(try queue.nextItem(), nil)
         queue.mode = .shuffle
-        XCTAssertEqual(try! queue.nextItem(), nil)
+        XCTAssertEqual(try queue.nextItem(), nil)
     }
 
     func testHasNextItemInQueue() {
-        let queue = AudioItemQueue(items: [item1, item2, item3], mode: [.normal])
+        let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
         XCTAssert(queue.hasNextItem)
-        XCTAssertNotNil(try! queue.nextItem())
+        XCTAssertNotNil(try queue.nextItem())
         XCTAssert(queue.hasNextItem)
-        XCTAssertNotNil(try! queue.nextItem())
+        XCTAssertNotNil(try queue.nextItem())
         XCTAssert(queue.hasNextItem)
-        XCTAssertNotNil(try! queue.nextItem())
+        XCTAssertNotNil(try queue.nextItem())
         XCTAssertFalse(queue.hasNextItem)
 
         queue.mode = .repeat
         for _ in 0...100 {
-            XCTAssertNotNil(try! queue.nextItem())
+            XCTAssertNotNil(try queue.nextItem())
             XCTAssert(queue.hasNextItem)
         }
 
         queue.mode = .repeatAll
         for _ in 0...100 {
-            XCTAssertNotNil(try! queue.nextItem())
+            XCTAssertNotNil(try queue.nextItem())
             XCTAssert(queue.hasNextItem)
         }
 
@@ -138,11 +138,11 @@ class AudioItemQueue_Tests: XCTestCase {
     func testPreviousInNormalMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
         XCTAssertFalse(queue.hasPreviousItem)
-        XCTAssertNil(try! queue.previousItem())
+        XCTAssertNil(try queue.previousItem())
 
-        XCTAssertNotNil(try! queue.nextItem())
+        XCTAssertNotNil(try queue.nextItem())
         XCTAssert(queue.hasNextItem)
-        XCTAssert((try! queue.previousItem()) === item1)
+        XCTAssert((try queue.previousItem()) === item1)
     }
 
     func testPreviousInRepeatMode() {
@@ -150,15 +150,15 @@ class AudioItemQueue_Tests: XCTestCase {
         XCTAssert(queue.hasPreviousItem)
 
         for _ in 0...100 {
-            XCTAssert((try! queue.previousItem()) === item1)
+            XCTAssert((try queue.previousItem()) === item1)
         }
 
         queue.mode = .normal
-        XCTAssert(queue.nextItem() === item2)
+        XCTAssert(try queue.nextItem() === item2)
 
         queue.mode = .repeat
         for _ in 0...100 {
-            XCTAssert(queue.previousItem() === item2)
+            XCTAssert(try queue.previousItem() === item2)
         }
     }
 
@@ -166,15 +166,15 @@ class AudioItemQueue_Tests: XCTestCase {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeatAll)
         for _ in 0...100 {
             XCTAssert(queue.hasPreviousItem)
-            XCTAssert((try! queue.previousItem()) === item3)
-            XCTAssert((try! queue.previousItem()) === item2)
-            XCTAssert((try! queue.previousItem()) === item1)
+            XCTAssert((try queue.previousItem()) === item3)
+            XCTAssert((try queue.previousItem()) === item2)
+            XCTAssert((try queue.previousItem()) === item1)
         }
     }
 
     func testPreviousItemWhenQueueIsEmpty() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssertEqual(try! queue.previousItem(), nil)
+        XCTAssertEqual(try queue.previousItem(), nil)
     }
 
     func testAddItemInQueue() {

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -188,4 +188,10 @@ class AudioItemQueue_Tests: XCTestCase {
         queue.remove(at: 2)
         XCTAssertEqual(queue.queue, [item1, item2])
     }
+
+    func testEmptyQueueHasNoPreviousNorNextItem() {
+        let queue = AudioItemQueue(items: [], mode: .normal)
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssertFalse(queue.hasNextItem)
+    }
 }

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -16,16 +16,16 @@ class AudioItemQueue_Tests: XCTestCase {
 
     func testEmptyQueueGivesNilAsNextItem() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssert(queue.nextItem() === nil)
+        XCTAssert((try! queue.nextItem()) === nil)
     }
 
     func testQueueInNormalModeAndHistoric() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
-        XCTAssert(queue.nextItem() === item1)
-        XCTAssert(queue.nextItem() === item2)
-        XCTAssert(queue.nextItem() === item3)
-        XCTAssert(queue.nextItem() === nil)
-        XCTAssert(queue.nextItem() === nil)
+        XCTAssert((try! queue.nextItem()) === item1)
+        XCTAssert((try! queue.nextItem()) === item2)
+        XCTAssert((try! queue.nextItem()) === item3)
+        XCTAssert((try! queue.nextItem()) === nil)
+        XCTAssert((try! queue.nextItem()) === nil)
 
         XCTAssertEqual(queue.historic.count, 3)
         XCTAssert(queue.historic[0] === item1)
@@ -40,40 +40,40 @@ class AudioItemQueue_Tests: XCTestCase {
     func testQueueInRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
         for _ in 0...100 {
-            XCTAssert(queue.nextItem() === item1)
+            XCTAssert((try! queue.nextItem()) === item1)
         }
     }
 
     func testQueueInRepeatAllMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeatAll)
         for _ in 0...100 {
-            XCTAssert(queue.nextItem() === item1)
-            XCTAssert(queue.nextItem() === item2)
-            XCTAssert(queue.nextItem() === item3)
+            XCTAssert((try! queue.nextItem()) === item1)
+            XCTAssert((try! queue.nextItem()) === item2)
+            XCTAssert((try! queue.nextItem()) === item3)
         }
     }
 
     func testQueueInNormalModelAfterSwitchingIfFromRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
-        _ = queue.nextItem()
+        _ = try! queue.nextItem()
 
         queue.mode = .normal
-        XCTAssert(queue.nextItem() === item2)
+        XCTAssert((try! queue.nextItem()) === item2)
 
         let queue2 = AudioItemQueue(items: [item1], mode: .repeat)
-        _ = queue2.nextItem()
+        _ = try! queue2.nextItem()
 
         queue2.mode = .normal
-        XCTAssert(queue2.nextItem() === nil)
+        XCTAssert((try! queue2.nextItem()) === nil)
     }
 
     func testQueueInShuffleModeAfterSwitchingItFromNormalMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
-        XCTAssert(queue.nextItem() === item1)
+        XCTAssert((try! queue.nextItem()) === item1)
 
         queue.mode = .shuffle
         for _ in 0...100 {
-            XCTAssert(queue.nextItem() !== item1)
+            XCTAssert((try! queue.nextItem()) !== item1)
         }
         queue.nextPosition = 0
         queue.mode = .normal
@@ -81,10 +81,10 @@ class AudioItemQueue_Tests: XCTestCase {
 
     func testQueueInShuffleModeCombinedWithRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: [.repeat, .shuffle])
-        let item = queue.nextItem()
+        let item = try! queue.nextItem()
 
         for _ in 0...100 {
-            XCTAssert(queue.nextItem() === item)
+            XCTAssert(try! queue.nextItem() === item)
         }
     }
 
@@ -93,37 +93,37 @@ class AudioItemQueue_Tests: XCTestCase {
         let queued = queue.queue
 
         for _ in 0...100 {
-            let q = [queue.nextItem()!, queue.nextItem()!, queue.nextItem()!]
+            let q = try! [queue.nextItem()!, queue.nextItem()!, queue.nextItem()!]
             XCTAssertEqual(queued, q)
         }
     }
 
     func testAdaptModeWhenQueueIsEmpty() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssertEqual(queue.nextItem(), nil)
+        XCTAssertEqual(try! queue.nextItem(), nil)
         queue.mode = .shuffle
-        XCTAssertEqual(queue.nextItem(), nil)
+        XCTAssertEqual(try! queue.nextItem(), nil)
     }
 
     func testHasNextItemInQueue() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: [.normal])
         XCTAssert(queue.hasNextItem)
-        _ = queue.nextItem()
+        _ = try! queue.nextItem()
         XCTAssert(queue.hasNextItem)
-        _ = queue.nextItem()
+        _ = try! queue.nextItem()
         XCTAssert(queue.hasNextItem)
-        _ = queue.nextItem()
+        _ = try! queue.nextItem()
         XCTAssertFalse(queue.hasNextItem)
 
         queue.mode = .repeat
         for _ in 0...100 {
-            _ = queue.nextItem()
+            _ = try! queue.nextItem()
             XCTAssert(queue.hasNextItem)
         }
 
         queue.mode = .repeatAll
         for _ in 0...100 {
-            _ = queue.nextItem()
+            _ = try! queue.nextItem()
             XCTAssert(queue.hasNextItem)
         }
 
@@ -138,17 +138,11 @@ class AudioItemQueue_Tests: XCTestCase {
     func testPreviousInNormalMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .normal)
         XCTAssertFalse(queue.hasPreviousItem)
-        XCTAssertNil(queue.previousItem())
+        XCTAssertNil(try! queue.previousItem())
 
-        //Start off the queue
-        _ = queue.nextItem()
-
-        //Go to item 2
-        XCTAssert(queue.nextItem() === item2)
+        _ = try! queue.nextItem()
         XCTAssert(queue.hasNextItem)
-
-        XCTAssert(queue.hasPreviousItem)
-        XCTAssert(queue.previousItem() === item1)
+        XCTAssert((try! queue.previousItem()) === item1)
     }
 
     func testPreviousInRepeatMode() {
@@ -156,7 +150,7 @@ class AudioItemQueue_Tests: XCTestCase {
         XCTAssert(queue.hasPreviousItem)
 
         for _ in 0...100 {
-            XCTAssert(queue.previousItem() === item1)
+            XCTAssert((try! queue.previousItem()) === item1)
         }
 
         queue.mode = .normal
@@ -172,15 +166,15 @@ class AudioItemQueue_Tests: XCTestCase {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeatAll)
         for _ in 0...100 {
             XCTAssert(queue.hasPreviousItem)
-            XCTAssert(queue.previousItem() === item3)
-            XCTAssert(queue.previousItem() === item2)
-            XCTAssert(queue.previousItem() === item1)
+            XCTAssert((try! queue.previousItem()) === item3)
+            XCTAssert((try! queue.previousItem()) === item2)
+            XCTAssert((try! queue.previousItem()) === item1)
         }
     }
 
     func testPreviousItemWhenQueueIsEmpty() {
         let queue = AudioItemQueue(items: [], mode: .normal)
-        XCTAssertEqual(queue.previousItem(), nil)
+        XCTAssertEqual(try! queue.previousItem(), nil)
     }
 
     func testAddItemInQueue() {


### PR DESCRIPTION
This PR is an implementation of what is discussed in #61. The goal here is to define at runtime - and before an item is played - if an `AudioItem` should be played or not.

This allows the original request to disable remote items when WiFi connection is down, but also allows other use cases.

Here's the todo list:
- [x]  Added a delegate method to check if an item is playable or not
- [x]  Use that method in `AudioItemQueue` to return the correct values in `nextItem()`, `hasNextItem`, `previousItem()` and `hasPreviousItem`.
- [x] Verify the implementation with new unit tests.
