### PR TITLE
Feature: Buffering Strategy & Settings

### DIFF
--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
 		653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
 		BB5E356D1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */; };
+		BBEC49BA1EC8D2C300BAB484 /* AudioPlayerBufferingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */; };
+		BBEC49BB1EC8D2C400BAB484 /* AudioPlayerBufferingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -643,6 +645,7 @@
 				46AADEE91CA1BA5A00CF7A3D /* BackgroundHandler.swift in Sources */,
 				46D3A3251C943ECC00635FE4 /* AudioItem.swift in Sources */,
 				467D61251CB111E800D50807 /* AudioPlayer+AudioItemEvent.swift in Sources */,
+				BBEC49BB1EC8D2C400BAB484 /* AudioPlayerBufferingStrategy.swift in Sources */,
 				46D3A30F1C933A8200635FE4 /* CMTime+TimeIntervalValue.swift in Sources */,
 				467D61291CB1145000D50807 /* URL+Offline.swift in Sources */,
 				46DAE4BD1C40275F00572EB2 /* Reachability.swift in Sources */,
@@ -660,6 +663,7 @@
 				46DE850F1CAB07DE00F00287 /* AudioPlayer+Queue.swift in Sources */,
 				46D3A2EA1C8F4A7B00635FE4 /* NetworkEventProducer.swift in Sources */,
 				467D61241CB111E800D50807 /* AudioPlayer+AudioItemEvent.swift in Sources */,
+				BBEC49BA1EC8D2C300BAB484 /* AudioPlayerBufferingStrategy.swift in Sources */,
 				46D3A3141C93405400635FE4 /* QualityAdjustmentEventProducer.swift in Sources */,
 				467D61281CB1145000D50807 /* URL+Offline.swift in Sources */,
 				653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */,

--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		46F956091C97385400923EE1 /* AudioItemEventProducer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F956081C97385400923EE1 /* AudioItemEventProducer_Tests.swift */; };
 		653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
 		653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
+		BB5E356D1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +167,7 @@
 		46F956081C97385400923EE1 /* AudioItemEventProducer_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioItemEventProducer_Tests.swift; sourceTree = "<group>"; };
 		653E18801C353DD0003C0CAB /* AudioPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AudioPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		653E18841C353DD0003C0CAB /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioPlayerBufferingStrategy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -302,6 +304,7 @@
 				46D3A3091C93389500635FE4 /* AudioPlayerState.swift */,
 				46D3A3001C90A93400635FE4 /* AudioPlayerDelegate.swift */,
 				462FC8021C9D7C33005A674B /* AudioPlayerMode.swift */,
+				BB5E356C1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift */,
 			);
 			path = player;
 			sourceTree = "<group>";
@@ -568,6 +571,7 @@
 				46DE850E1CAB07DE00F00287 /* AudioPlayer+Queue.swift in Sources */,
 				462679681AED5DDC003771C9 /* AudioPlayer.swift in Sources */,
 				467D61231CB111E800D50807 /* AudioPlayer+AudioItemEvent.swift in Sources */,
+				BB5E356D1EC3738F001BF508 /* AudioPlayerBufferingStrategy.swift in Sources */,
 				46D3A2E91C8F4A7B00635FE4 /* NetworkEventProducer.swift in Sources */,
 				467D61271CB1145000D50807 /* URL+Offline.swift in Sources */,
 				46D3A3131C93405400635FE4 /* QualityAdjustmentEventProducer.swift in Sources */,

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -228,7 +228,7 @@ public class AudioPlayer: NSObject {
     public var preferredBufferDurationBeforePlayback = TimeInterval(60)
     
     /// Defines the preferred size of the forward buffer for the underlying `AVPlayerItem`.
-    /// Works on iOS/tvOS 10+, default is 0, which lets `AVPlayer` decice.
+    /// Works on iOS/tvOS 10+, default is 0, which lets `AVPlayer` decide.
     public var preferredForwardBufferDuration = TimeInterval(0)
 
     /// Defines how to behave when the user is seeking through the lockscreen or the control center.
@@ -393,7 +393,7 @@ public class AudioPlayer: NSObject {
     
     /// Updates the current player based on the current buffering strategy.
     /// Only has an effect on iOS 10+, tvOS 10+ and macOS 10.12+
-    internal func updatePlayerForBufferingStrategy() {
+    func updatePlayerForBufferingStrategy() {
         if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
             player?.automaticallyWaitsToMinimizeStalling = self.bufferingStrategy != .playWhenBufferNotEmpty
         }
@@ -401,7 +401,7 @@ public class AudioPlayer: NSObject {
     
     /// Updates a given player item based on the `preferredForwardBufferDuration` set.
     /// Only has an effect on iOS 10+, tvOS 10+ and macOS 10.12+
-    internal func updatePlayerItemForBufferingStrategy(_ playerItem: AVPlayerItem) {
+    func updatePlayerItemForBufferingStrategy(_ playerItem: AVPlayerItem) {
         //Nothing strategy-specific yet
         if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
             playerItem.preferredForwardBufferDuration = self.preferredForwardBufferDuration

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -216,7 +216,7 @@ public class AudioPlayer: NSObject {
         }
     }
     
-    /// buffering strategy
+    /// Defines the buffering strategy used to determine how much to buffer before starting playback
     public var bufferingStrategy: AudioPlayerBufferingStrategy = .defaultBuffering {
         didSet {
             updatePlayerForBufferingStrategy()
@@ -224,11 +224,11 @@ public class AudioPlayer: NSObject {
     }
     
     /// Defines the preferred buffer duration in seconds before playback begins. Defaults to 60.
-    /// Works on iOS 10+ when `bufferingStrategy` is `.playWhenPreferredBufferDurationFull`.
+    /// Works on iOS/tvOS 10+ when `bufferingStrategy` is `.playWhenPreferredBufferDurationFull`.
     public var preferredBufferDurationBeforePlayback = TimeInterval(60)
     
     /// Defines the preferred size of the forward buffer for the underlying `AVPlayerItem`.
-    /// Works on iOS 10+, default is 0, which lets `AVPlayer` decice.
+    /// Works on iOS/tvOS 10+, default is 0, which lets `AVPlayer` decice.
     public var preferredForwardBufferDuration = TimeInterval(0)
 
     /// Defines how to behave when the user is seeking through the lockscreen or the control center.

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -100,9 +100,17 @@ public class AudioPlayer: NSObject {
                     backgroundHandler.beginBackgroundTask()
                     return
                 }
+                
+                //Create new AVPlayerItem
+                let playerItem = AVPlayerItem(url: info.url)
+                
+                if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
+                    playerItem.preferredForwardBufferDuration = self.preferredForwardBufferDuration
+                }
 
                 //Creates new player
-                player = AVPlayer(url: info.url)
+                player = AVPlayer(playerItem: playerItem)
+                
                 currentQuality = info.quality
 
                 //Updates information on the lock screen
@@ -206,6 +214,17 @@ public class AudioPlayer: NSObject {
             }
         }
     }
+    
+    /// buffering strategy
+    public var bufferingStrategy: AudioPlayerBufferingStrategy = .aggressiveBuffering
+    
+    /// Defines the preferred buffer duration in seconds before playback begins. Defaults to `60`.
+    /// This only has an effect on iOS 10+ when bufferingStrategy is `.aggressive`.
+    public var prebufferDurationBeforePlaying = TimeInterval(60)
+    
+    /// Defines the preferred size of the forward buffer for the underlying AVPlayerItem.
+    /// This onle has an effect of iOS 10+, default is 0, which lets AVPlayer decice.
+    public var preferredForwardBufferDuration = TimeInterval(0)
 
     /// Defines how to behave when the user is seeking through the lockscreen or the control center.
     ///

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
@@ -8,15 +8,16 @@
 
 import Foundation
 
+/// Represents the strategy used for buffering of items before playback is started
 @objc public enum AudioPlayerBufferingStrategy: Int {
     /// Uses the default AVPlayer buffering strategy, which buffers very aggressively before starting playback.
     /// This often leads to start of playback being delayed more than necessary.
     case defaultBuffering = 0
     
-    /// Uses a strategy better at quickly starting playback, but might lead to stalls on slower connections.
-    /// Uses `prebufferDurationBeforePlayback` to determine when to start playback. Requires iOS 10+ to have any effect.
+    /// Uses a strategy better at quickly starting playback. Duration to buffer before playback is customizable through
+    /// the `prebufferDurationBeforePlayback` variable. Requires iOS/tvOS 10+ to have any effect.
     case playWhenPreferredBufferDurationFull = 1
     
-    /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty. Requires iOS 10+ to have any effect.
+    /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty. Requires iOS/tvOS 10+ to have any effect.
     case playWhenBufferNotEmpty = 2
 }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
@@ -17,6 +17,6 @@ import Foundation
     /// Uses `prebufferDurationBeforePlayback` to determine when to start playback. Requires iOS 10+ to have any effect.
     case playWhenPreferredBufferDurationFull = 1
     
-    /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty
+    /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty. Requires iOS 10+ to have any effect.
     case playWhenBufferNotEmpty = 2
 }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
@@ -1,0 +1,14 @@
+//
+//  AudioPlayerBufferingStrategy.swift
+//  AudioPlayer
+//
+//  Created by Daniel Dam Freiling on 10/05/2017.
+//  Copyright © 2017 Kevin Delannoy. All rights reserved.
+//
+
+import Foundation
+
+@objc public enum AudioPlayerBufferingStrategy: Int {
+    case defaultBuffering = 0
+    case aggressiveBuffering = 1
+}

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
@@ -15,7 +15,7 @@ import Foundation
     case defaultBuffering = 0
     
     /// Uses a strategy better at quickly starting playback. Duration to buffer before playback is customizable through
-    /// the `prebufferDurationBeforePlayback` variable. Requires iOS/tvOS 10+ to have any effect.
+    /// the `preferredBufferDurationBeforePlayback` variable. Requires iOS/tvOS 10+ to have any effect.
     case playWhenPreferredBufferDurationFull = 1
     
     /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty. Requires iOS/tvOS 10+ to have any effect.

--- a/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayerBufferingStrategy.swift
@@ -2,13 +2,21 @@
 //  AudioPlayerBufferingStrategy.swift
 //  AudioPlayer
 //
-//  Created by Daniel Dam Freiling on 10/05/2017.
+//  Created by Daniel Freiling on 10/05/2017.
 //  Copyright © 2017 Kevin Delannoy. All rights reserved.
 //
 
 import Foundation
 
 @objc public enum AudioPlayerBufferingStrategy: Int {
+    /// Uses the default AVPlayer buffering strategy, which buffers very aggressively before starting playback.
+    /// This often leads to start of playback being delayed more than necessary.
     case defaultBuffering = 0
-    case aggressiveBuffering = 1
+    
+    /// Uses a strategy better at quickly starting playback, but might lead to stalls on slower connections.
+    /// Uses `prebufferDurationBeforePlayback` to determine when to start playback. Requires iOS 10+ to have any effect.
+    case playWhenPreferredBufferDurationFull = 1
+    
+    /// Uses a strategy that simply starts playback whenever the AVPlayerItem buffer is non-empty
+    case playWhenBufferNotEmpty = 2
 }

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
@@ -38,6 +38,17 @@ extension AudioPlayer {
         //app is in foreground.
         backgroundHandler.beginBackgroundTask()
     }
+    
+    /// Starts playing the current item immediately. Works on iOS/tvOS 10+ and macOS 10.12+
+    func playImmediately() {
+        if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
+            self.state = .playing
+            player?.playImmediately(atRate: rate)
+            
+            retryEventProducer.stopProducingEvents()
+            backgroundHandler.endBackgroundTask()
+        }
+    }
 
     /// Plays previous item in the queue or rewind current item.
     public func previous() {

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+CurrentItem.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+CurrentItem.swift
@@ -44,4 +44,9 @@ extension AudioPlayer {
         }
         return nil
     }
+    
+    public var currentItemLoadedDuration: TimeInterval? {
+        guard let loadedRange = currentItemLoadedRange else { return nil }
+        return loadedRange.latest - loadedRange.earliest
+    }
 }

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+CurrentItem.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+CurrentItem.swift
@@ -45,8 +45,12 @@ extension AudioPlayer {
         return nil
     }
     
-    public var currentItemLoadedDuration: TimeInterval? {
-        guard let loadedRange = currentItemLoadedRange else { return nil }
-        return loadedRange.latest - loadedRange.earliest
+    public var currentItemLoadedAhead: TimeInterval? {
+        if  let loadedRange = currentItemLoadedRange,
+            let currentTime = player?.currentTime(),
+                loadedRange.earliest <= currentTime.seconds {
+            return loadedRange.latest - currentTime.seconds
+        }
+        return nil
     }
 }

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -47,31 +47,14 @@ extension AudioPlayer {
             }
 
         case .loadedMoreRange:
-            if let currentItem = currentItem,
-                let currentItemLoadedRange = currentItemLoadedRange,
-                let currentItemLoadedDuration = currentItemLoadedDuration {
+            if let currentItem = currentItem, let currentItemLoadedRange = currentItemLoadedRange {
                 delegate?.audioPlayer(self, didLoad: currentItemLoadedRange, for: currentItem)
                 
-                if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
-                    if  state == .buffering || state == .waitingForConnection,
-                        bufferingStrategy == .playWhenPreferredBufferDurationFull,
-                        let player = player,
-                        let currentItem = player.currentItem,
-                        currentItemLoadedDuration.isNormal {
-                        
-                        var minBufferDuration = self.preferredBufferDurationBeforePlayback
-                        if currentItem.duration.seconds.isNormal &&
-                            currentItem.duration.seconds < minBufferDuration {
-                           minBufferDuration = currentItem.duration.seconds
-                        }
-                        if (currentItemLoadedDuration >= minBufferDuration) {
-                            self.state = .playing
-                            player.playImmediately(atRate: self.rate)
-                            //TODO: is this neccessary? done in .readyToPlay case
-                            retryEventProducer.stopProducingEvents()
-                            backgroundHandler.endBackgroundTask()
-                        }
-                    }
+                if bufferingStrategy == .playWhenPreferredBufferDurationFull && state == .buffering,
+                    let currentItemLoadedAhead = currentItemLoadedAhead,
+                    currentItemLoadedAhead.isNormal,
+                    currentItemLoadedAhead >= self.preferredBufferDurationBeforePlayback {
+                        playImmediately()
                 }
             }
 

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+QualityAdjustmentEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+QualityAdjustmentEvent.swift
@@ -46,6 +46,9 @@ extension AudioPlayer {
 
         let cip = currentItemProgression
         let item = AVPlayerItem(url: url)
+        if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
+            item.preferredForwardBufferDuration = self.preferredForwardBufferDuration
+        }
 
         qualityIsBeingChanged = true
         player?.replaceCurrentItem(with: item)

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+QualityAdjustmentEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+QualityAdjustmentEvent.swift
@@ -46,9 +46,7 @@ extension AudioPlayer {
 
         let cip = currentItemProgression
         let item = AVPlayerItem(url: url)
-        if #available(iOS 10.0, tvOS 10.0, OSX 10.12, *) {
-            item.preferredForwardBufferDuration = self.preferredForwardBufferDuration
-        }
+        self.updatePlayerItemForBufferingStrategy(item)
 
         qualityIsBeingChanged = true
         player?.replaceCurrentItem(with: item)


### PR DESCRIPTION
- Added a bufferingStrategy variable with 3 settings:
  - **defaultBuffering** - Nothing changed, AVPlayer has full control of buffering duration before playback
  - **playWhenPreferredBufferDurationFull** - Playback is started when a preferred buffer duration has been reached. Customizable through `preferredBufferDurationBeforePlayback` variable.
  - **playWhenBufferNotEmpty** - Sets automaticallyWaitsToMinimizeStalling to false, which makes playback start whenever the buffer contains any playable data. See [Apple Docs](https://developer.apple.com/reference/avfoundation/avplayer/1643482-automaticallywaitstominimizestal).
- Player now has a `preferredForwardBufferDuration` variable which is propagated onto all AVPlayerItems. See [Apple Docs](https://developer.apple.com/reference/avfoundation/avplayeritem/1643630-preferredforwardbufferduration).
- These features only has an effect on iOS/tvOS 10+ and macOS 10.12+ and does nothing on platform versions below.