### PR TITLE
[WiP] Cache and preload items in the queue

### DIFF
--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
 		653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
 		BB3ED56C1EC4993400AA0C30 /* AudioPlayer+Preload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */; };
+		BBEC49BC1EC8D3EA00BAB484 /* AudioPlayer+Preload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */; };
+		BBEC49BD1EC8D3EA00BAB484 /* AudioPlayer+Preload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -638,7 +640,7 @@
 				46DDB0A01C959D3C007B60C6 /* AudioItemEventProducer.swift in Sources */,
 				467D611D1CB1113500D50807 /* AudioPlayer+NetworkEvent.swift in Sources */,
 				46D3A3021C90A93800635FE4 /* AudioPlayerDelegate.swift in Sources */,
-				BB3ED56E1EC4993A00AA0C30 /* AudioPlayer+Preload.swift in Sources */,
+				BBEC49BD1EC8D3EA00BAB484 /* AudioPlayer+Preload.swift in Sources */,
 				467D61211CB1119600D50807 /* AudioPlayer+QualityAdjustmentEvent.swift in Sources */,
 				46D3A31D1C9340D000635FE4 /* AudioItemQueue.swift in Sources */,
 				46AADEE91CA1BA5A00CF7A3D /* BackgroundHandler.swift in Sources */,
@@ -679,7 +681,7 @@
 				653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */,
 				467D61201CB1119600D50807 /* AudioPlayer+QualityAdjustmentEvent.swift in Sources */,
 				460FA1E61CC1814500156DFC /* AudioPlayer+RetryEvent.swift in Sources */,
-				BB3ED56D1EC4993A00AA0C30 /* AudioPlayer+Preload.swift in Sources */,
+				BBEC49BC1EC8D3EA00BAB484 /* AudioPlayer+Preload.swift in Sources */,
 				46DE850B1CAB067400F00287 /* AudioPlayer+Control.swift in Sources */,
 				460FA1E01CBA946F00156DFC /* RetryEventProducer.swift in Sources */,
 			);

--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		46F956091C97385400923EE1 /* AudioItemEventProducer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F956081C97385400923EE1 /* AudioItemEventProducer_Tests.swift */; };
 		653E188C1C3541B8003C0CAB /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462679671AED5DDC003771C9 /* AudioPlayer.swift */; };
 		653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466930791BAD30AB00C1E97C /* Reachability.swift */; };
+		BB3ED56C1EC4993400AA0C30 /* AudioPlayer+Preload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +167,7 @@
 		46F956081C97385400923EE1 /* AudioItemEventProducer_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioItemEventProducer_Tests.swift; sourceTree = "<group>"; };
 		653E18801C353DD0003C0CAB /* AudioPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AudioPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		653E18841C353DD0003C0CAB /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AudioPlayer+Preload.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -330,6 +332,7 @@
 			children = (
 				46DE85091CAB067400F00287 /* AudioPlayer+Control.swift */,
 				46DE850D1CAB07DE00F00287 /* AudioPlayer+Queue.swift */,
+				BB3ED56B1EC4993400AA0C30 /* AudioPlayer+Preload.swift */,
 				46DE85111CAB0A3200F00287 /* AudioPlayer+CurrentItem.swift */,
 				46BF0BCD1DC2DED900560FD1 /* AudioPlayer+SeekEvent.swift */,
 				467D61161CB110BD00D50807 /* AudioPlayer+PlayerEvent.swift */,
@@ -586,6 +589,7 @@
 				4669307A1BAD30AB00C1E97C /* Reachability.swift in Sources */,
 				467D611F1CB1119600D50807 /* AudioPlayer+QualityAdjustmentEvent.swift in Sources */,
 				460FA1E51CC1814500156DFC /* AudioPlayer+RetryEvent.swift in Sources */,
+				BB3ED56C1EC4993400AA0C30 /* AudioPlayer+Preload.swift in Sources */,
 				46DE850A1CAB067400F00287 /* AudioPlayer+Control.swift in Sources */,
 				460FA1DF1CBA946F00156DFC /* RetryEventProducer.swift in Sources */,
 			);
@@ -634,6 +638,7 @@
 				46DDB0A01C959D3C007B60C6 /* AudioItemEventProducer.swift in Sources */,
 				467D611D1CB1113500D50807 /* AudioPlayer+NetworkEvent.swift in Sources */,
 				46D3A3021C90A93800635FE4 /* AudioPlayerDelegate.swift in Sources */,
+				BB3ED56E1EC4993A00AA0C30 /* AudioPlayer+Preload.swift in Sources */,
 				467D61211CB1119600D50807 /* AudioPlayer+QualityAdjustmentEvent.swift in Sources */,
 				46D3A31D1C9340D000635FE4 /* AudioItemQueue.swift in Sources */,
 				46AADEE91CA1BA5A00CF7A3D /* BackgroundHandler.swift in Sources */,
@@ -674,6 +679,7 @@
 				653E188D1C3541BB003C0CAB /* Reachability.swift in Sources */,
 				467D61201CB1119600D50807 /* AudioPlayer+QualityAdjustmentEvent.swift in Sources */,
 				460FA1E61CC1814500156DFC /* AudioPlayer+RetryEvent.swift in Sources */,
+				BB3ED56D1EC4993A00AA0C30 /* AudioPlayer+Preload.swift in Sources */,
 				46DE850B1CAB067400F00287 /* AudioPlayer+Control.swift in Sources */,
 				460FA1E01CBA946F00156DFC /* RetryEventProducer.swift in Sources */,
 			);

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -50,6 +50,9 @@ public class AudioPlayer: NSObject {
 
     /// The queue containing items to play.
     var queue: AudioItemQueue?
+    
+    /// Cached AVAssets, mainly used for preloading next item.
+    var cachedAssets: [URL: AVURLAsset] = [:]
 
     /// The audio player.
     var player: AVPlayer? {

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -84,6 +84,8 @@ extension AudioPlayer {
                 player?.rate = 0
                 state = .paused
             }
+            
+            preloadNextItemAsset()
 
             //TODO: where to start?
             retryEventProducer.stopProducingEvents()

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Preload.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Preload.swift
@@ -1,0 +1,77 @@
+//
+//  AudioPlayer+Preload.swift
+//  AudioPlayer
+//
+//  Created by Daniel Dam Freiling on 11/05/2017.
+//  Copyright © 2017 Kevin Delannoy. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+
+extension AudioPlayer {
+    
+    public static let assetPreloadKeys = ["tracks", "playable"]
+    
+    public func clearAssetCache() {
+        cachedAssets = [:]
+    }
+    
+    public func getAVURLAsset(forUrl: URL) -> AVURLAsset {
+        if let asset = cachedAssets[forUrl],
+               asset.isPlayable {
+            return asset
+        } else {
+            let asset = AVURLAsset(url: forUrl)
+            cachedAssets[forUrl] = asset
+            return asset
+        }
+    }
+    
+    public func getPlayerItem(forUrl: URL) -> AVPlayerItem {
+        let asset = getAVURLAsset(forUrl: forUrl)
+        let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: AudioPlayer.assetPreloadKeys)
+        return playerItem
+    }
+    
+    public func preloadItemAsset(asset: AVURLAsset, onComplete: @escaping (AVURLAsset?) -> Void) {
+        asset.loadValuesAsynchronously(forKeys: AudioPlayer.assetPreloadKeys) {
+            if (self.assetPreloadKeysAreLoaded(asset: asset) == false) {
+                //loading failed, invalidate cached asset
+                self.cachedAssets.removeValue(forKey: asset.url)
+                onComplete(nil)
+            } else {
+                onComplete(asset)
+            }
+        }
+    }
+    
+    public func preloadNextItemAsset() {
+        if hasNext, let queue = queue {
+            let nextPosition = queue.nextPosition
+            let item = queue.items[nextPosition]
+            let urlInfo = item.highestQualityURL
+            let asset = getAVURLAsset(forUrl: urlInfo.url)
+            print("preloading queue idx: \(nextPosition)")
+            preloadItemAsset(asset: asset) { asset in
+                if (asset == nil) {
+                    print("error preloading queue idx: \(nextPosition)")
+                } else {
+                    print("preloaded queue idx: \(nextPosition)!")
+                }
+            }
+        }
+    }
+    
+    private func assetPreloadKeysAreLoaded(asset: AVURLAsset) -> Bool {
+        for key in AudioPlayer.assetPreloadKeys {
+            var error: NSError?
+            let result = asset.statusOfValue(forKey: key, error: &error)
+            if (result != .loaded || error != nil) {
+                print("AVAsset failed to load key '\(key)': (\(String(describing: result))) \(String(describing: error?.localizedDescription))")
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Queue.swift
@@ -41,6 +41,7 @@ extension AudioPlayer {
     ///   - index: The index to start the player with.
     public func play(items: [AudioItem], startAtIndex index: Int = 0) {
         if !items.isEmpty {
+            cachedAssets = [:]
             queue = AudioItemQueue(items: items, mode: mode)
             if let realIndex = queue?.queue.index(of: items[index]) {
                 queue?.nextPosition = realIndex
@@ -76,6 +77,11 @@ extension AudioPlayer {
     ///
     /// - Parameter index: The index of the item to remove.
     public func removeItem(at index: Int) {
-        queue?.remove(at: index)
+        if let item = queue?.queue[index] {
+            for urlInfo in item.soundURLs {
+                cachedAssets.removeValue(forKey: urlInfo.value)
+            }
+            queue?.remove(at: index)
+        }
     }
 }


### PR DESCRIPTION
WIP - Need feedback
- General caching of played AVAssets, means going back to items in the playlist previously played and fully buffered, are now re-used and not started from scratch download-wise.
- Now preloads the next item in the queue when current item is readyToPlay (playbackLikelyToKeepUp).

TODO: May need a strategy setting for when to start preloading the next item (if at all).
Strategies idea:
- **None**. No preloading
- **OnReady**. When current item is readyToPlay (playbackLikelyToKeepUp event), start preloading next
- **OnBufferFull**. When current item's buffer is full (bufferFull event), start preloading next
- **OnFullyLoaded**. When current item is fully loaded (loadedRange == duration), start preloading next

NOTE: Maybe prebuffering will work better if we use an AVQueuePlayer instead of AVPlayer? Any experience with this? Need to check Docs.

Thoughts?