### PR TITLE
Bugfix: Interruption ended

### DIFF
--- a/AudioPlayer/AudioPlayer/event/PlayerEventProducer.swift
+++ b/AudioPlayer/AudioPlayer/event/PlayerEventProducer.swift
@@ -70,7 +70,7 @@ class PlayerEventProducer: NSObject, EventProducer {
         case progressed(CMTime)
         case endedPlaying(Error?)
         case interruptionBegan
-        case interruptionEnded
+        case interruptionEnded(Bool)
         case routeChanged
         case sessionMessedUp
     }
@@ -238,9 +238,8 @@ class PlayerEventProducer: NSObject, EventProducer {
             } else {
                 if let optionInt = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
                     let options = AVAudioSessionInterruptionOptions(rawValue: optionInt)
-                    if options.contains(.shouldResume) {
-                        eventListener?.onEvent(PlayerEvent.interruptionEnded, generetedBy: self)
-                    }
+                    let shouldResume = options.contains(.shouldResume)
+                    eventListener?.onEvent(PlayerEvent.interruptionEnded(shouldResume), generetedBy: self)
                 }
             }
         }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -345,7 +345,7 @@ public class AudioPlayer: NSObject {
 
     /// Boolean value indicating whether the player should resume playing (after buffering)
     var shouldResumePlaying: Bool {
-        return !pausedForInterruption && !state.isPaused &&
+        return !state.isPaused &&
             (stateWhenConnectionLost.map { !$0.isPaused } ?? true) &&
             (stateBeforeBuffering.map { !$0.isPaused } ?? true)
     }

--- a/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
+++ b/AudioPlayer/AudioPlayer/player/AudioPlayer.swift
@@ -100,6 +100,9 @@ public class AudioPlayer: NSObject {
                     backgroundHandler.beginBackgroundTask()
                     return
                 }
+                
+                //Reset special state flags
+                pausedForInterruption = false
 
                 //Creates new player
                 player = AVPlayer(url: info.url)

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+Control.swift
@@ -14,6 +14,9 @@ import CoreMedia
 extension AudioPlayer {
     /// Resumes the player.
     public func resume() {
+        //Ensure pause flag is no longer set
+        pausedForInterruption = false
+        
         player?.rate = rate
 
         //We don't wan't to change the state to Playing in case it's Buffering. That

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -27,8 +27,8 @@ extension AudioPlayer {
             pausedForInterruption = true
             pause()
 
-        case .interruptionEnded where pausedForInterruption:
-            if resumeAfterInterruption {
+        case .interruptionEnded(let shouldResume) where pausedForInterruption:
+            if resumeAfterInterruption && shouldResume {
                 resume()
             }
             pausedForInterruption = false

--- a/AudioPlayer/AudioPlayerTests/AudioPlayer+PlayerEvent_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioPlayer+PlayerEvent_Tests.swift
@@ -41,7 +41,7 @@ class AudioPlayer_PlayerEvent_Tests: XCTestCase {
         }
         player.delegate = delegate
 
-        player.handlePlayerEvent(from: player.playerEventProducer, with: .progressed(CMTime(timeInterval: 2)))
+        player.handlePlayerEvent(from: player.playerEventProducer, with: .progressed(time: CMTime(timeInterval: 2)))
         waitForExpectations(timeout: 1) { e in
             if let _ = e {
                 XCTFail()
@@ -64,7 +64,7 @@ class AudioPlayer_PlayerEvent_Tests: XCTestCase {
         }
         player.delegate = delegate
 
-        player.handlePlayerEvent(from: player.playerEventProducer, with: .progressed(CMTime(timeInterval: 2)))
+        player.handlePlayerEvent(from: player.playerEventProducer, with: .progressed(time: CMTime(timeInterval: 2)))
         waitForExpectations(timeout: 1) { e in
             if let _ = e {
                 XCTFail()


### PR DESCRIPTION
This fixes #66

- Receiving audio interruptions from un-resumable sources like Spotify and YouTube would leave the player in a very bad state with the `pausedForInterruption` flag set indefinitely.
- `pausedForInterruption` is now reset on resume, currentItem set, and on any interruptionEnded callback, whether it has the shouldResume option or not.

@delannoyk [this commit](https://github.com/delannoyk/AudioPlayer/pull/115/commits/2769b9205f9e23b306186a5439cb4064f4ff839c) I need feedback on, am I correct that the check on `pausedForInterruption` flag is unnecessary in `shouldResumePlaying`?