### PR TITLE
Fix bug: AudioPlayer's state not paused after a route change event

### DIFF
--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Kevin Delannoy. All rights reserved.
 //
 
+import CoreMedia
+
 extension AudioPlayer {
     /// Handles player events.
     ///
@@ -99,7 +101,7 @@ extension AudioPlayer {
         case .routeChanged:
             //In some route changes, the player pause automatically
             //TODO: there should be a check if state == playing
-            if let player = player, player.rate == 0 {
+            if let currentItemTimebase = player?.currentItem?.timebase, CMTimebaseGetRate(currentItemTimebase) == 0 {
                 state = .paused
             }
 


### PR DESCRIPTION
We noticed a bug where the player's state wasn't being updated to `paused` after a route change, for instance, when unplugging the headphones. After some research, the reason seems to be that `AVPlayer.rate` doesn't indicate the current playback rate anymore, but the _requested_ one. Instead, we should check `AVPlayerItem.timebase.rate`, which is _the rate at which playback is actually occurring_.

At first, I tried using the `AVPlayer.timeControlStatus` property (since iOS 10), which supposes to tell us either if the player is _paused_, _waiting to play at specific rate_, or _playing_, but it's not yet updated when the changed route event happens (which is weird, to be honest).

More info in this [WWDC 2016 session](https://developer.apple.com/videos/play/wwdc2016/503).