### PR TITLE
next/previous item for normal mode

### DIFF
--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -201,7 +201,7 @@ class AudioItemQueue {
     /// A boolean value indicating whether the queue has a previous item to play or not.
     var hasPreviousItem: Bool {
         if !queue.isEmpty &&
-            ((nextPosition > 0 && queue.count > 1) || mode.contains(.repeat) || mode.contains(.repeatAll)) {
+            (nextPosition > 1 || mode.contains(.repeat) || mode.contains(.repeatAll)) {
             return true
         }
         return false

--- a/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
+++ b/AudioPlayer/AudioPlayer/item/AudioItemQueue.swift
@@ -178,12 +178,14 @@ class AudioItemQueue {
         if mode.contains(.repeatAll) && nextPosition <= 0 {
             nextPosition = queue.count
         }
-
+        
         while nextPosition > 0 {
-            let previousPosition = nextPosition - 1
+            var previousPosition = nextPosition - 1
             nextPosition = previousPosition
+            if previousPosition == queue.count - 1 && mode == .normal {
+                previousPosition -= 1
+            }
             let item = queue[previousPosition]
-
             if shouldConsiderItem(item: item) {
                 historic.append(item)
                 return item
@@ -199,7 +201,7 @@ class AudioItemQueue {
     /// A boolean value indicating whether the queue has a previous item to play or not.
     var hasPreviousItem: Bool {
         if !queue.isEmpty &&
-            (nextPosition > 0 || mode.contains(.repeat) || mode.contains(.repeatAll)) {
+            ((nextPosition > 0 && queue.count > 1) || mode.contains(.repeat) || mode.contains(.repeatAll)) {
             return true
         }
         return false

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -156,6 +156,32 @@ class AudioItemQueue_Tests: XCTestCase {
         XCTAssert(queue.hasNextItem)
         XCTAssert(queue.previousItem() === item1)
     }
+    
+    func testPreviousWithTwoItems() {
+        let queue = AudioItemQueue(items: [item1, item2], mode: .normal)
+        print("1: \(queue.nextPosition)")
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssert(queue.nextItem() === item1)
+        print("2: \(queue.nextPosition)")
+        XCTAssertTrue(queue.hasPreviousItem)
+        XCTAssert(queue.nextItem() === item2)
+        print("3: \(queue.nextPosition)")
+        XCTAssertTrue(queue.hasPreviousItem)
+        XCTAssert(queue.previousItem() === item1)
+        print("4: \(queue.nextPosition)")
+        XCTAssert(queue.nextItem() === item2)
+        print("5: \(queue.nextPosition)")
+    }
+    
+    func testPreviousWithOneItem() {
+        let queue = AudioItemQueue(items: [item1], mode: .normal)
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssertTrue(queue.hasNextItem)
+        
+        XCTAssert(queue.nextItem() === item1)
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssertFalse(queue.hasNextItem)
+    }
 
     func testPreviousInRepeatMode() {
         let queue = AudioItemQueue(items: [item1, item2, item3], mode: .repeat)
@@ -214,7 +240,6 @@ class AudioItemQueue_Tests: XCTestCase {
         queue.nextPosition = queue.queue.count
         queue.delegate = delegate
 
-        XCTAssert(queue.previousItem() === item3)
         XCTAssert(queue.previousItem() === item1)
         XCTAssertNil(queue.previousItem())
     }

--- a/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/AudioItemQueue_Tests.swift
@@ -157,20 +157,26 @@ class AudioItemQueue_Tests: XCTestCase {
         XCTAssert(queue.previousItem() === item1)
     }
     
-    func testPreviousWithTwoItems() {
+    func testHasPrevious() {
         let queue = AudioItemQueue(items: [item1, item2], mode: .normal)
-        print("1: \(queue.nextPosition)")
         XCTAssertFalse(queue.hasPreviousItem)
         XCTAssert(queue.nextItem() === item1)
-        print("2: \(queue.nextPosition)")
-        XCTAssertTrue(queue.hasPreviousItem)
+        XCTAssertFalse(queue.hasPreviousItem)
         XCTAssert(queue.nextItem() === item2)
-        print("3: \(queue.nextPosition)")
         XCTAssertTrue(queue.hasPreviousItem)
         XCTAssert(queue.previousItem() === item1)
-        print("4: \(queue.nextPosition)")
         XCTAssert(queue.nextItem() === item2)
-        print("5: \(queue.nextPosition)")
+    }
+    
+    func testPreviousWithTwoItems() {
+        let queue = AudioItemQueue(items: [item1, item2], mode: .normal)
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssert(queue.nextItem() === item1)
+        XCTAssertFalse(queue.hasPreviousItem)
+        XCTAssert(queue.nextItem() === item2)
+        XCTAssertTrue(queue.hasPreviousItem)
+        XCTAssert(queue.previousItem() === item1)
+        XCTAssert(queue.nextItem() === item2)
     }
     
     func testPreviousWithOneItem() {


### PR DESCRIPTION
There seems to be a problem with previous/next in normal mode:
1) previous/next should be always false for queues with one item
2) when reaching the end of the list, the previous item returned should not be the last item

Maybe there is a better approach, this is just a suggestion 😀