### PR TITLE
[FIX] Play immediately where is enough data in the buffer

### DIFF
--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -89,6 +89,7 @@ extension AudioPlayer {
                 stateBeforeBuffering = nil
                 state = .playing
                 player?.rate = rate
+                playImmediately()
             } else {
                 player?.rate = 0
                 state = .paused


### PR DESCRIPTION
Player has sufficient data to play in `.readToPlay` and stays paused for a long time