### PR TITLE
Fix route change issue after interruption

### DIFF
--- a/AudioPlayer/AudioPlayer/event/PlayerEventProducer.swift
+++ b/AudioPlayer/AudioPlayer/event/PlayerEventProducer.swift
@@ -72,7 +72,7 @@ class PlayerEventProducer: NSObject, EventProducer {
         case endedPlaying(error: Error?)
         case interruptionBegan
         case interruptionEnded(shouldResume: Bool)
-        case routeChanged
+        case routeChanged(reason: AVAudioSession.RouteChangeReason)
         case sessionMessedUp
     }
 
@@ -260,7 +260,10 @@ class PlayerEventProducer: NSObject, EventProducer {
     ///
     /// - Parameter note: The notification information.
     @objc fileprivate func audioSessionRouteChanged(note: NSNotification) {
-        eventListener?.onEvent(PlayerEvent.routeChanged, generetedBy: self)
+        let reason = note.userInfo
+            .flatMap({ $0[AVAudioSessionRouteChangeReasonKey] as? UInt })
+            .map(AVAudioSession.RouteChangeReason.init) as? AVAudioSession.RouteChangeReason ?? .unknown
+        eventListener?.onEvent(PlayerEvent.routeChanged(reason: reason), generetedBy: self)
     }
 
     /// Audio session got messed up (media services lost or reset). We gotta reactive the audio session and reset

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -99,10 +99,13 @@ extension AudioPlayer {
             retryEventProducer.stopProducingEvents()
             backgroundHandler.endBackgroundTask()
 
-        case .routeChanged:
-            //In some route changes, the player pause automatically
-            //TODO: there should be a check if state == playing
-            if let currentItemTimebase = player?.currentItem?.timebase, CMTimebaseGetRate(currentItemTimebase) == 0 {
+        case .routeChanged(let reason):
+            // When a route changes because a device got disconnected (e.g. unplugged headphones)
+            // the player can be paused. This interruption must respect interruptionBegan.
+            //TODO: Handle other reasons.
+            if reason == .oldDeviceUnavailable,
+                let currentItemTimebase = player?.currentItem?.timebase,
+                CMTimebaseGetRate(currentItemTimebase) == 0 {
                 state = .paused
             }
 

--- a/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/AudioPlayer/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -99,11 +99,11 @@ extension AudioPlayer {
             retryEventProducer.stopProducingEvents()
             backgroundHandler.endBackgroundTask()
 
-        case .routeChanged(let reason):
+        case .routeChanged(let deviceDisconnected):
             // When a route changes because a device got disconnected (e.g. unplugged headphones)
             // the player can be paused. This interruption must respect interruptionBegan.
             //TODO: Handle other reasons.
-            if reason == .oldDeviceUnavailable,
+            if deviceDisconnected,
                 let currentItemTimebase = player?.currentItem?.timebase,
                 CMTimebaseGetRate(currentItemTimebase) == 0 {
                 state = .paused

--- a/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
@@ -137,13 +137,15 @@ class PlayerEventProducer_Tests: XCTestCase {
             name: AVAudioSession.interruptionNotification,
             object: player,
             userInfo: [
-                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began.rawValue
             ])
 
         let expectationEnds = expectation(description: "Waiting for `onEvent` to get called")
         listener.eventClosure = { event, producer in
-            if case PlayerEventProducer.PlayerEvent.interruptionEnded = event {
-                expectationEnds.fulfill()
+            if case PlayerEventProducer.PlayerEvent.interruptionEnded(let shouldResume) = event {
+                if shouldResume {
+                    expectationEnds.fulfill()
+                }
             }
         }
 
@@ -151,8 +153,8 @@ class PlayerEventProducer_Tests: XCTestCase {
             name: AVAudioSession.interruptionNotification,
             object: AVAudioSession.sharedInstance(),
             userInfo: [
-                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.ended,
-                AVAudioSessionInterruptionOptionKey: AVAudioSession.InterruptionOptions.shouldResume
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.ended.rawValue,
+                AVAudioSessionInterruptionOptionKey: AVAudioSession.InterruptionOptions.shouldResume.rawValue
             ])
 
         waitForExpectations(timeout: 1) { e in

--- a/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
@@ -111,8 +111,8 @@ class PlayerEventProducer_Tests: XCTestCase {
         let e = expectation(description: "Waiting for `onEvent` to get called")
         listener.eventClosure = { event, producer in
             if let event = event as? PlayerEventProducer.PlayerEvent,
-                case PlayerEventProducer.PlayerEvent.routeChanged = event {
-                    e.fulfill()
+                case PlayerEventProducer.PlayerEvent.routeChanged(let reason) = event {
+                if reason == .unknown { e.fulfill() }
             }
         }
 

--- a/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
+++ b/AudioPlayer/AudioPlayerTests/PlayerEventProducer_Tests.swift
@@ -111,12 +111,15 @@ class PlayerEventProducer_Tests: XCTestCase {
         let e = expectation(description: "Waiting for `onEvent` to get called")
         listener.eventClosure = { event, producer in
             if let event = event as? PlayerEventProducer.PlayerEvent,
-                case PlayerEventProducer.PlayerEvent.routeChanged(let reason) = event {
-                if reason == .unknown { e.fulfill() }
+                case PlayerEventProducer.PlayerEvent.routeChanged(let deviceDisconnected) = event {
+                if deviceDisconnected { e.fulfill() }
             }
         }
 
-        NotificationCenter.default.post(name: AVAudioSession.routeChangeNotification, object: AVAudioSession.sharedInstance())
+        NotificationCenter.default.post(
+            name: AVAudioSession.routeChangeNotification,
+            object: AVAudioSession.sharedInstance(),
+            userInfo: [AVAudioSessionRouteChangeReasonKey: AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue])
 
         waitForExpectations(timeout: 1) { e in
             if let _ = e {


### PR DESCRIPTION
This PR fixes an issue where interruptions were also causing route changes, making the stream not resume after them because the player was explicitly paused. The code now checks that the route change was actually caused because a device was disconnected before pausing the player and it doesn't do it if it wasn't the case (e.g. in the middle of an interruption).

This seems to be a new, undocumented behavior in the underlying AVPlayer.

It also:
- Initialises `InterruptionType` and `InterruptionOptions` from the raw value instead of just casting them.
- Fixes the tests according to the change above, making them more robust.

It's been a month since the fix was deployed in production on my end and so far so good.