### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Carthage/Build
 sonar*
 .sonar
 
+# DS Store banned
+.DS_Store


### PR DESCRIPTION
I deleted the previous PR because the history wasn't good. This PR will stop `git` from adding `DS_Store` automatically.